### PR TITLE
correcting device tree node for temperature node

### DIFF
--- a/zephyr/boards/shields/twist/adc-channels.dtsi
+++ b/zephyr/boards/shields/twist/adc-channels.dtsi
@@ -102,9 +102,9 @@
 			channel-name = "TEMP_SENSOR";
 			default-gain = <0x3f800000>;
 			default-offset = <0x00000000>;
-			spin-pin = <37>;
+			spin-pin = <31>;
 			temp-sensor-adc3 {
-				io-channels = <&adc3 1>;
+				io-channels = <&adc3 12>;
 			};
 		};
 


### PR DESCRIPTION
On twist, the pin for temperature sensor has been moved PB1 to PB0 and use ADC 3 channel 12. This commit will update the information within the device tree. 