### PR TITLE
Fix Data API behavior when using software-triggered acquisitions

### DIFF
--- a/zephyr/modules/owntech_data_api/zephyr/public_api/DataAPI.cpp
+++ b/zephyr/modules/owntech_data_api/zephyr/public_api/DataAPI.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 LAAS-CNRS
+ * Copyright (c) 2022-2024 LAAS-CNRS
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU Lesser General Public License as published by
@@ -18,7 +18,7 @@
  */
 
 /**
- * @date   2023
+ * @date   2024
  *
  * @author Clément Foucher <clement.foucher@laas.fr>
  * @author Luiz Villa <luiz.villa@laas.fr>
@@ -211,7 +211,6 @@ void DataAPI::triggerAcquisition(uint8_t adc_num)
 {
 	uint8_t enabled_channels = spin.adc.getEnabledChannelsCount(adc_num);
 	spin.adc.triggerSoftwareConversion(adc_num, enabled_channels);
-
 }
 
 uint16_t* DataAPI::getRawValues(uint8_t adc_num, uint8_t pin_num, uint32_t& number_of_values_acquired)
@@ -342,8 +341,6 @@ int8_t DataAPI::enableChannel(uint8_t adc_num, uint8_t channel_num)
 	spin.adc.enableDma(adc_num, true);
 	spin.adc.enableChannel(adc_num, channel_num);
 
-
-
 	// Remember rank
 	uint8_t adc_index = adc_num-1;
 	uint8_t channel_index = channel_num-1;
@@ -433,7 +430,7 @@ float32_t DataAPI::getChannelLatest(uint8_t adc_num, uint8_t channel_num, uint8_
 		float32_t peekValue;
 		if (raw_value != PEEK_NO_VALUE)
 		{
-			data_conversion_convert_raw_value(adc_num, channel_num, raw_value);
+			peekValue = data_conversion_convert_raw_value(adc_num, channel_num, raw_value);
 		}
 		else
 		{

--- a/zephyr/modules/owntech_data_api/zephyr/public_api/DataAPI.h
+++ b/zephyr/modules/owntech_data_api/zephyr/public_api/DataAPI.h
@@ -296,7 +296,7 @@ public:
 	 * @note  This function requires Console to interact with the user.
 	 *        You must first call console_init() before calling this function.
 	 *
-	 * @note  This function can't be called before the *all* Twist channels have
+	 * @note  This function can't be called before *all* Twist channels have
 	 *        been enabled (you can use enableTwistDefaultChannels() for that
 	 *        purpose). The DataAPI must not have been started, neither
 	 *        explicitly nor by starting the Uninterruptible task.

--- a/zephyr/modules/owntech_data_api/zephyr/src/data_dispatch.cpp
+++ b/zephyr/modules/owntech_data_api/zephyr/src/data_dispatch.cpp
@@ -135,8 +135,9 @@ void data_dispatch_init(dispatch_t dispatch_method, uint32_t repetitions)
 	for (uint8_t adc_num = 1 ; adc_num <= ADC_COUNT ; adc_num++)
 	{
 		uint8_t adc_index = adc_num-1;
-		enabled_channels_count[adc_index] =  spin.adc.getEnabledChannelsCount(adc_num);
+		enabled_channels_count[adc_index] = spin.adc.getEnabledChannelsCount(adc_num);
 
+		// Ignore this ADC if it has no enabled channel
 		if (enabled_channels_count[adc_index] > 0)
 		{
 			// Prepare buffers for DMA


### PR DESCRIPTION
When using software-triggered acquisitions using `data.triggerAcquisition()`, the DMA did not reload its base address automatically at buffer end.
This patch should solve this issue by using callback status to detect that buffer end was reached, and trigger a DMA reload.
Also fixes an issue where the latest peeked value was not correctly returned when no new acquisition was available.