### PR TITLE
Fixing typo in spdx identifier.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/boards/arm/spin/Kconfig.board
+++ b/zephyr/boards/arm/spin/Kconfig.board
@@ -1,5 +1,5 @@
 # Copyright (c) 2023 OwnTech
-# SPDX-License-Identifier: LGLPV2.1
+# SPDX-License-Identifier: LGPL-2.1
 
 # OwnTech board Kconfig definition
 

--- a/zephyr/boards/arm/spin/gpio.dtsi
+++ b/zephyr/boards/arm/spin/gpio.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 

--- a/zephyr/boards/arm/spin/spin.dts
+++ b/zephyr/boards/arm/spin/spin.dts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022-2024 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /dts-v1/;

--- a/zephyr/boards/arm/spin/spin.yaml
+++ b/zephyr/boards/arm/spin/spin.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) 2022-2023 OwnTech
-# SPDX-License-Identifier: LGLPV2.1
+# SPDX-License-Identifier: LGPL-2.1
 
 identifier: spin
 name: OwnTech Spin

--- a/zephyr/boards/arm/spin/spin_defconfig
+++ b/zephyr/boards/arm/spin/spin_defconfig
@@ -1,5 +1,5 @@
 # Copyright (c) 2022-2023 OwnTech
-# SPDX-License-Identifier: LGLPV2.1
+# SPDX-License-Identifier: LGPL-2.1
 
 # Spin default Kconfig configuration
 

--- a/zephyr/boards/arm/spin/spin_header.dtsi
+++ b/zephyr/boards/arm/spin/spin_header.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 / {

--- a/zephyr/boards/nucleo_g474re.conf
+++ b/zephyr/boards/nucleo_g474re.conf
@@ -1,5 +1,5 @@
 # Copyright (c) 2024 OwnTech
-# SPDX-License-Identifier: LGLPV2.1
+# SPDX-License-Identifier: LGPL-2.1
 
 # Enable and configure USB
 CONFIG_USB_DEVICE_STACK=y

--- a/zephyr/boards/nucleo_g474re.overlay
+++ b/zephyr/boards/nucleo_g474re.overlay
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022-2024 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 

--- a/zephyr/boards/shields/twist/Kconfig.shield
+++ b/zephyr/boards/shields/twist/Kconfig.shield
@@ -1,5 +1,5 @@
 # Copyright (c) 2023 OwnTech
-# SPDX-License-Identifier: LGLPV2.1
+# SPDX-License-Identifier: LGPL-2.1
 
 config SHIELD_TWIST
 	def_bool $(shields_list_contains,twist)

--- a/zephyr/boards/shields/twist/adc-channels.dtsi
+++ b/zephyr/boards/shields/twist/adc-channels.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022-2023 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 / {

--- a/zephyr/boards/shields/twist/can-standby-switch.dtsi
+++ b/zephyr/boards/shields/twist/can-standby-switch.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 / {

--- a/zephyr/boards/shields/twist/ngnd.dtsi
+++ b/zephyr/boards/shields/twist/ngnd.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
  / {

--- a/zephyr/boards/shields/twist/pwm_legs.dtsi
+++ b/zephyr/boards/shields/twist/pwm_legs.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 / {

--- a/zephyr/boards/shields/twist/safety-thresholds.dtsi
+++ b/zephyr/boards/shields/twist/safety-thresholds.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2024 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 / {

--- a/zephyr/boards/shields/twist/twist.overlay
+++ b/zephyr/boards/shields/twist/twist.overlay
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023-2024 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 #include "can-standby-switch.dtsi"

--- a/zephyr/dts/adc.dtsi
+++ b/zephyr/dts/adc.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  *
  * Ideally, this file's content should be contributed
  * to Zephyr's definition of STM32G4 SOC.

--- a/zephyr/dts/bindings/gpio/spin-header.yaml
+++ b/zephyr/dts/bindings/gpio/spin-header.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) 2023 OwnTech
-# SPDX-License-Identifier: LGLPV2.1
+# SPDX-License-Identifier: LGPL-2.1
 
 description: |
     GPIO pins exposed on OwnTech Spin headers.

--- a/zephyr/dts/hrtim.dtsi
+++ b/zephyr/dts/hrtim.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
  / {

--- a/zephyr/dts/pinctrl.dtsi
+++ b/zephyr/dts/pinctrl.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022 OwnTech.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 / {

--- a/zephyr/modules/owntech_adc_driver/zephyr/public_api/adc.c
+++ b/zephyr/modules/owntech_adc_driver/zephyr/public_api/adc.c
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_adc_driver/zephyr/public_api/adc.h
+++ b/zephyr/modules/owntech_adc_driver/zephyr/public_api/adc.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_adc_driver/zephyr/src/adc_core.c
+++ b/zephyr/modules/owntech_adc_driver/zephyr/src/adc_core.c
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_adc_driver/zephyr/src/adc_core.h
+++ b/zephyr/modules/owntech_adc_driver/zephyr/src/adc_core.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/public_api/CommunicationAPI.cpp
+++ b/zephyr/modules/owntech_communication/zephyr/public_api/CommunicationAPI.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/public_api/CommunicationAPI.h
+++ b/zephyr/modules/owntech_communication/zephyr/public_api/CommunicationAPI.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/src/AnalogCommunication.cpp
+++ b/zephyr/modules/owntech_communication/zephyr/src/AnalogCommunication.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/src/AnalogCommunication.h
+++ b/zephyr/modules/owntech_communication/zephyr/src/AnalogCommunication.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/src/CanCommunication.cpp
+++ b/zephyr/modules/owntech_communication/zephyr/src/CanCommunication.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/src/CanCommunication.h
+++ b/zephyr/modules/owntech_communication/zephyr/src/CanCommunication.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/src/Rs485.cpp
+++ b/zephyr/modules/owntech_communication/zephyr/src/Rs485.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/src/Rs485.h
+++ b/zephyr/modules/owntech_communication/zephyr/src/Rs485.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/src/Rs485Communication.cpp
+++ b/zephyr/modules/owntech_communication/zephyr/src/Rs485Communication.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/src/Rs485Communication.h
+++ b/zephyr/modules/owntech_communication/zephyr/src/Rs485Communication.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/src/SyncCommunication.cpp
+++ b/zephyr/modules/owntech_communication/zephyr/src/SyncCommunication.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_communication/zephyr/src/SyncCommunication.h
+++ b/zephyr/modules/owntech_communication/zephyr/src/SyncCommunication.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_comparator_driver/zephyr/public_api/comparator.c
+++ b/zephyr/modules/owntech_comparator_driver/zephyr/public_api/comparator.c
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_comparator_driver/zephyr/public_api/comparator.h
+++ b/zephyr/modules/owntech_comparator_driver/zephyr/public_api/comparator.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_comparator_driver/zephyr/src/comparator_driver.c
+++ b/zephyr/modules/owntech_comparator_driver/zephyr/src/comparator_driver.c
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_comparator_driver/zephyr/src/comparator_driver.h
+++ b/zephyr/modules/owntech_comparator_driver/zephyr/src/comparator_driver.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_dac_driver/zephyr/public_api/dac.h
+++ b/zephyr/modules/owntech_dac_driver/zephyr/public_api/dac.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_dac_driver/zephyr/src/stm32_dac_driver.c
+++ b/zephyr/modules/owntech_dac_driver/zephyr/src/stm32_dac_driver.c
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_dac_driver/zephyr/src/stm32_dac_driver.h
+++ b/zephyr/modules/owntech_dac_driver/zephyr/src/stm32_dac_driver.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/public_api/DataAPI.cpp
+++ b/zephyr/modules/owntech_data_api/zephyr/public_api/DataAPI.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/public_api/DataAPI.h
+++ b/zephyr/modules/owntech_data_api/zephyr/public_api/DataAPI.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/public_api/data_api_internal.h
+++ b/zephyr/modules/owntech_data_api/zephyr/public_api/data_api_internal.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/src/data_conversion.cpp
+++ b/zephyr/modules/owntech_data_api/zephyr/src/data_conversion.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/src/data_conversion.h
+++ b/zephyr/modules/owntech_data_api/zephyr/src/data_conversion.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/src/data_dispatch.cpp
+++ b/zephyr/modules/owntech_data_api/zephyr/src/data_dispatch.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/src/data_dispatch.h
+++ b/zephyr/modules/owntech_data_api/zephyr/src/data_dispatch.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/src/dma.cpp
+++ b/zephyr/modules/owntech_data_api/zephyr/src/dma.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/src/dma.h
+++ b/zephyr/modules/owntech_data_api/zephyr/src/dma.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/src/shield_channels.cpp
+++ b/zephyr/modules/owntech_data_api/zephyr/src/shield_channels.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_data_api/zephyr/src/shield_channels.h
+++ b/zephyr/modules/owntech_data_api/zephyr/src/shield_channels.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_flash_driver/zephyr/public_api/nvs_storage.c
+++ b/zephyr/modules/owntech_flash_driver/zephyr/public_api/nvs_storage.c
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_flash_driver/zephyr/public_api/nvs_storage.h
+++ b/zephyr/modules/owntech_flash_driver/zephyr/public_api/nvs_storage.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_hrtim_driver/zephyr/public_api/hrtim.h
+++ b/zephyr/modules/owntech_hrtim_driver/zephyr/public_api/hrtim.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /*

--- a/zephyr/modules/owntech_hrtim_driver/zephyr/public_api/hrtim_enum.h
+++ b/zephyr/modules/owntech_hrtim_driver/zephyr/public_api/hrtim_enum.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_hrtim_driver/zephyr/src/hrtim.c
+++ b/zephyr/modules/owntech_hrtim_driver/zephyr/src/hrtim.c
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_ngnd_driver/zephyr/public_api/ngnd.h
+++ b/zephyr/modules/owntech_ngnd_driver/zephyr/public_api/ngnd.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_ngnd_driver/zephyr/src/owntech_ngnd_driver.c
+++ b/zephyr/modules/owntech_ngnd_driver/zephyr/src/owntech_ngnd_driver.c
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_ngnd_driver/zephyr/src/owntech_ngnd_driver.h
+++ b/zephyr/modules/owntech_ngnd_driver/zephyr/src/owntech_ngnd_driver.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_power_api/zephyr/public_api/TwistAPI.cpp
+++ b/zephyr/modules/owntech_power_api/zephyr/public_api/TwistAPI.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_power_api/zephyr/public_api/TwistAPI.h
+++ b/zephyr/modules/owntech_power_api/zephyr/public_api/TwistAPI.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_power_api/zephyr/src/power_init.cpp
+++ b/zephyr/modules/owntech_power_api/zephyr/src/power_init.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_power_api/zephyr/src/power_init.h
+++ b/zephyr/modules/owntech_power_api/zephyr/src/power_init.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_safety_api/zephyr/public_api/SafetyAPI.cpp
+++ b/zephyr/modules/owntech_safety_api/zephyr/public_api/SafetyAPI.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_safety_api/zephyr/public_api/SafetyAPI.h
+++ b/zephyr/modules/owntech_safety_api/zephyr/public_api/SafetyAPI.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_safety_api/zephyr/public_api/safety_internal.h
+++ b/zephyr/modules/owntech_safety_api/zephyr/public_api/safety_internal.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_safety_api/zephyr/src/safety_enum.h
+++ b/zephyr/modules/owntech_safety_api/zephyr/src/safety_enum.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_safety_api/zephyr/src/safety_setting.cpp
+++ b/zephyr/modules/owntech_safety_api/zephyr/src/safety_setting.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_safety_api/zephyr/src/safety_setting.h
+++ b/zephyr/modules/owntech_safety_api/zephyr/src/safety_setting.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_safety_api/zephyr/src/safety_shield.cpp
+++ b/zephyr/modules/owntech_safety_api/zephyr/src/safety_shield.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_safety_api/zephyr/src/safety_shield.h
+++ b/zephyr/modules/owntech_safety_api/zephyr/src/safety_shield.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/public_api/SpinAPI.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/public_api/SpinAPI.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/AdcHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/AdcHAL.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/AdcHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/AdcHAL.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/CompHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/CompHAL.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/CompHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/CompHAL.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/DacHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/DacHAL.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/DacHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/DacHAL.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/GpioHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/GpioHAL.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/GpioHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/GpioHAL.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/LedHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/LedHAL.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/LedHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/LedHAL.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/NgndHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/NgndHAL.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/NgndHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/NgndHAL.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/TimerHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/TimerHAL.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/TimerHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/TimerHAL.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/UartHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/UartHAL.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/UartHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/UartHAL.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/VersionHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/VersionHAL.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/VersionHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/VersionHAL.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_spin_api/zephyr/src/hardware_auto_configuration.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/hardware_auto_configuration.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_task_api/zephyr/public_api/TaskAPI.cpp
+++ b/zephyr/modules/owntech_task_api/zephyr/public_api/TaskAPI.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_task_api/zephyr/public_api/TaskAPI.h
+++ b/zephyr/modules/owntech_task_api/zephyr/public_api/TaskAPI.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_task_api/zephyr/src/asynchronous_tasks.cpp
+++ b/zephyr/modules/owntech_task_api/zephyr/src/asynchronous_tasks.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_task_api/zephyr/src/asynchronous_tasks.hpp
+++ b/zephyr/modules/owntech_task_api/zephyr/src/asynchronous_tasks.hpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_task_api/zephyr/src/scheduling_common.cpp
+++ b/zephyr/modules/owntech_task_api/zephyr/src/scheduling_common.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_task_api/zephyr/src/scheduling_common.hpp
+++ b/zephyr/modules/owntech_task_api/zephyr/src/scheduling_common.hpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_task_api/zephyr/src/uninterruptible_synchronous_task.cpp
+++ b/zephyr/modules/owntech_task_api/zephyr/src/uninterruptible_synchronous_task.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_task_api/zephyr/src/uninterruptible_synchronous_task.hpp
+++ b/zephyr/modules/owntech_task_api/zephyr/src/uninterruptible_synchronous_task.hpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_timer_driver/zephyr/public_api/timer.h
+++ b/zephyr/modules/owntech_timer_driver/zephyr/public_api/timer.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_timer_driver/zephyr/src/stm32_timer_driver.c
+++ b/zephyr/modules/owntech_timer_driver/zephyr/src/stm32_timer_driver.c
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**

--- a/zephyr/modules/owntech_timer_driver/zephyr/src/stm32_timer_driver.h
+++ b/zephyr/modules/owntech_timer_driver/zephyr/src/stm32_timer_driver.h
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * SPDX-License-Identifier: LGLPV2.1
+ * SPDX-License-Identifier: LGPL-2.1
  */
 
 /**


### PR DESCRIPTION
Fixing spdx name as per https://spdx.org/licenses/LGPL-2.1.html