### PR TITLE
Adding variable frequency, and solving HRTIM issues 

### DIFF
--- a/zephyr/modules/owntech_hrtim_driver/zephyr/public_api/hrtim.h
+++ b/zephyr/modules/owntech_hrtim_driver/zephyr/public_api/hrtim.h
@@ -286,7 +286,7 @@ void hrtim_cmpl_pwm_out2(hrtim_tu_number_t tu_number);
  *            @arg @ref PWMF
  * @param[in] tu_number        Timing unit number:
  */
-void hrtim_frequency_set(uint32_t value);
+void hrtim_frequency_set(uint32_t frequency_set, uint32_t frequency_min);
 
 /**
  * @brief   Returns the period of a given timing unit
@@ -729,7 +729,7 @@ hrtim_external_trigger_t hrtim_eev_get(hrtim_tu_number_t tu_number);
  * @param[in] new_frequency The new frequency in Hz
  * @warning the new frequency can't be inferior to the the one set in the initialization step
 */
-uint32_t hrtim_change_frequency(uint32_t new_frequency);
+void hrtim_change_frequency(uint32_t new_frequency);
 
 #ifdef __cplusplus
 }

--- a/zephyr/modules/owntech_hrtim_driver/zephyr/public_api/hrtim.h
+++ b/zephyr/modules/owntech_hrtim_driver/zephyr/public_api/hrtim.h
@@ -724,6 +724,13 @@ void hrtim_eev_set(hrtim_tu_number_t tu_number, hrtim_external_trigger_t eev);
  */
 hrtim_external_trigger_t hrtim_eev_get(hrtim_tu_number_t tu_number);
 
+/**
+ * @brief Change the frequency/period after it has been initialized.
+ * @param[in] new_frequency The new frequency in Hz
+ * @warning the new frequency can't be inferior to the the one set in the initialization step
+*/
+uint32_t hrtim_change_frequency(uint32_t new_frequency);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zephyr/modules/owntech_hrtim_driver/zephyr/src/hrtim.c
+++ b/zephyr/modules/owntech_hrtim_driver/zephyr/src/hrtim.c
@@ -548,7 +548,7 @@ inline uint16_t hrtim_period_Master_get()
 
 inline uint16_t hrtim_period_get(hrtim_tu_number_t tu_number)
 {
-    return tu_channel[tu_number]->pwm_conf.period; // returns the value of the period
+    return LL_HRTIM_TIM_GetPeriod(HRTIM1, tu_channel[tu_number]->pwm_conf.pwm_tu); // returns the value of the period
 }
 
 uint32_t hrtim_period_Master_get_us()

--- a/zephyr/modules/owntech_hrtim_driver/zephyr/src/hrtim.c
+++ b/zephyr/modules/owntech_hrtim_driver/zephyr/src/hrtim.c
@@ -548,7 +548,7 @@ inline uint16_t hrtim_period_Master_get()
 
 inline uint16_t hrtim_period_get(hrtim_tu_number_t tu_number)
 {
-    return LL_HRTIM_TIM_GetPeriod(HRTIM1, LL_HRTIM_TIMER_MASTER); // returns the value of the period
+    return LL_HRTIM_TIM_GetPeriod(HRTIM1, tu_channel[tu_number]->pwm_conf.pwm_tu); // returns the value of the period
 }
 
 uint32_t hrtim_period_Master_get_us()

--- a/zephyr/modules/owntech_hrtim_driver/zephyr/src/hrtim.c
+++ b/zephyr/modules/owntech_hrtim_driver/zephyr/src/hrtim.c
@@ -898,3 +898,42 @@ void DualDAC_init(hrtim_tu_number_t tu_number)
     LL_HRTIM_TIM_SetDualDacStepTrigger(HRTIM1, tu_channel[tu_number]->pwm_conf.pwm_tu, LL_HRTIM_DCDS_CMP2);
     LL_HRTIM_TIM_EnableDualDacTrigger(HRTIM1, tu_channel[tu_number]->pwm_conf.pwm_tu);
 }
+
+uint32_t hrtim_change_frequency(uint32_t new_frequency)
+{
+    uint32_t f_hrtim = hrtim_get_apb2_clock();
+    float32_t duty_cycle;
+    uint32_t period = ((f_hrtim / new_frequency) * 32 + (f_hrtim % new_frequency) * 32 / new_frequency) / (1 << timerMaster.pwm_conf.ckpsc);
+
+    if(timerMaster.pwm_conf.frequency <= new_frequency)
+    {
+        LL_HRTIM_TIM_SetPeriod(HRTIM1, LL_HRTIM_TIMER_MASTER, period);
+
+        duty_cycle = (float32_t)LL_HRTIM_TIM_GetCompare1(HRTIM1, LL_HRTIM_TIMER_A)/(float32_t)LL_HRTIM_TIM_GetPeriod(HRTIM1, LL_HRTIM_TIMER_A);
+        LL_HRTIM_TIM_SetPeriod(HRTIM1, LL_HRTIM_TIMER_A, period);
+        LL_HRTIM_TIM_SetCompare1(HRTIM1, LL_HRTIM_TIMER_A, duty_cycle*period);
+
+        duty_cycle = (float32_t)LL_HRTIM_TIM_GetCompare1(HRTIM1, LL_HRTIM_TIMER_C)/(float32_t)LL_HRTIM_TIM_GetPeriod(HRTIM1, LL_HRTIM_TIMER_C);
+        LL_HRTIM_TIM_SetPeriod(HRTIM1, LL_HRTIM_TIMER_C, period);
+        LL_HRTIM_TIM_SetCompare1(HRTIM1, LL_HRTIM_TIMER_C, duty_cycle*period);
+
+        duty_cycle = (float32_t)LL_HRTIM_TIM_GetCompare1(HRTIM1, LL_HRTIM_TIMER_D)/(float32_t)LL_HRTIM_TIM_GetPeriod(HRTIM1, LL_HRTIM_TIMER_D);
+        LL_HRTIM_TIM_SetPeriod(HRTIM1, LL_HRTIM_TIMER_D, period);
+        LL_HRTIM_TIM_SetCompare1(HRTIM1, LL_HRTIM_TIMER_D, duty_cycle*period);
+
+        duty_cycle = (float32_t)LL_HRTIM_TIM_GetCompare1(HRTIM1, LL_HRTIM_TIMER_E)/(float32_t)LL_HRTIM_TIM_GetPeriod(HRTIM1, LL_HRTIM_TIMER_E);
+        LL_HRTIM_TIM_SetPeriod(HRTIM1, LL_HRTIM_TIMER_E, period);
+        LL_HRTIM_TIM_SetCompare1(HRTIM1, LL_HRTIM_TIMER_E, duty_cycle*period);
+
+        duty_cycle = (float32_t)LL_HRTIM_TIM_GetCompare1(HRTIM1, LL_HRTIM_TIMER_F)/(float32_t)LL_HRTIM_TIM_GetPeriod(HRTIM1, LL_HRTIM_TIMER_F);
+        LL_HRTIM_TIM_SetPeriod(HRTIM1, LL_HRTIM_TIMER_F, period);
+        LL_HRTIM_TIM_SetCompare1(HRTIM1, LL_HRTIM_TIMER_F, duty_cycle*period);
+
+        duty_cycle = (float32_t)LL_HRTIM_TIM_GetCompare1(HRTIM1, LL_HRTIM_TIMER_B)/(float32_t)LL_HRTIM_TIM_GetPeriod(HRTIM1, LL_HRTIM_TIMER_B);
+        LL_HRTIM_TIM_SetPeriod(HRTIM1, LL_HRTIM_TIMER_B, period);
+        LL_HRTIM_TIM_SetCompare1(HRTIM1, LL_HRTIM_TIMER_B, duty_cycle*period);
+
+    }
+
+    return period;
+}

--- a/zephyr/modules/owntech_hrtim_driver/zephyr/src/hrtim.c
+++ b/zephyr/modules/owntech_hrtim_driver/zephyr/src/hrtim.c
@@ -548,7 +548,7 @@ inline uint16_t hrtim_period_Master_get()
 
 inline uint16_t hrtim_period_get(hrtim_tu_number_t tu_number)
 {
-    return LL_HRTIM_TIM_GetPeriod(HRTIM1, tu_channel[tu_number]->pwm_conf.pwm_tu); // returns the value of the period
+    return LL_HRTIM_TIM_GetPeriod(HRTIM1, LL_HRTIM_TIMER_MASTER); // returns the value of the period
 }
 
 uint32_t hrtim_period_Master_get_us()

--- a/zephyr/modules/owntech_power_api/zephyr/public_api/TwistAPI.cpp
+++ b/zephyr/modules/owntech_power_api/zephyr/public_api/TwistAPI.cpp
@@ -73,7 +73,7 @@ void TwistAPI::setVersion(twist_version_t twist_ver)
 
 void TwistAPI::initLegMode(leg_t leg, hrtim_switch_convention_t leg_convention, hrtim_pwm_mode_t leg_mode)
 {
-    spin.pwm.setFrequency(timer_frequency); // Configure PWM frequency
+    spin.pwm.initFrequency(timer_frequency); // Configure PWM frequency
 
     spin.pwm.setModulation(spinNumberToTu(dt_pwm_pin[leg]), dt_modulation[leg]); // Set modulation
 

--- a/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.cpp
@@ -171,11 +171,18 @@ void PwmHAL::setSwitchConvention(hrtim_tu_number_t pwmX, hrtim_switch_convention
 	hrtim_set_switch_convention(pwmX, convention);
 }
 
-void PwmHAL::setFrequency(uint32_t value)
+void PwmHAL::initFrequency(uint32_t init_frequency, uint32_t minimal_frequency)
 {
 	if (!hrtim_get_status(PWMA))
 		hrtim_init_default_all(); // initialize default parameters before
-	hrtim_frequency_set(value);
+	hrtim_frequency_set(init_frequency, minimal_frequency);
+}
+
+void PwmHAL::initFrequency(uint32_t init_frequency)
+{
+	if (!hrtim_get_status(PWMA))
+		hrtim_init_default_all(); // initialize default parameters before
+	hrtim_frequency_set(init_frequency, init_frequency);
 }
 
 void PwmHAL::setDeadTime(hrtim_tu_number_t pwmX, uint16_t rise_ns, uint16_t fall_ns)
@@ -345,7 +352,7 @@ void PwmHAL::setAdcDecimation(hrtim_tu_number_t pwmX, uint32_t decimation)
 	hrtim_adc_trigger_set_postscaler(pwmX, decimation - 1);
 }
 
-uint32_t PwmHAL::changeFrequency(uint32_t frequency_update)
+void PwmHAL::setFrequency(uint32_t frequency_update)
 {
-	return hrtim_change_frequency(frequency_update);
+	hrtim_change_frequency(frequency_update);
 }

--- a/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.cpp
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.cpp
@@ -344,3 +344,8 @@ void PwmHAL::setAdcDecimation(hrtim_tu_number_t pwmX, uint32_t decimation)
 		decimation = 1;
 	hrtim_adc_trigger_set_postscaler(pwmX, decimation - 1);
 }
+
+uint32_t PwmHAL::changeFrequency(uint32_t frequency_update)
+{
+	return hrtim_change_frequency(frequency_update);
+}

--- a/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.h
@@ -122,13 +122,24 @@ public:
      void setSwitchConvention(hrtim_tu_number_t pwmX, hrtim_switch_convention_t convention);
 
      /**
-      * @brief     This function sets the frequency
+      * @brief     This function initialize the frequency
       *
-      * @param[in] value frequency in Hz
+      * @param[in] init_frequency frequency in Hz
+      *
+      * @warning this function must be called BEFORE initialiazing any timing unit. 
+      *          the frequency initialized becomes the MINIMUM possible.
+      */
+     void initFrequency(uint32_t init_frequency);
+
+     /**
+      * @brief This functions initialize the frequency and also sets the minimal reachable frequency.
+      *
+      * @param[in] init_frequency frequency in Hz
+      * @param[in] minimal_frequency desired minimal frequency in Hz
       *
       * @warning this function must be called BEFORE initialiazing any timing unit
-      */
-     void setFrequency(uint32_t value);
+     */
+     void initFrequency(uint32_t init_frequency, uint32_t minimal_frequency);
 
      /**
       * @brief     This function sets the dead time for the selected timing unit
@@ -137,7 +148,7 @@ public:
       * @param[in] rise_ns		rising edge dead time in ns
       * @param[in] falling_ns	falling edge dead time in ns
       *
-      * @warning use this function AFTER initializing the chosen timer
+      * @warning use this function BEFORE initializing the chosen timer
       */
      void setDeadTime(hrtim_tu_number_t pwmX, uint16_t rise_ns, uint16_t fall_ns);
 
@@ -355,7 +366,7 @@ public:
       * @param[in] frequency_update The new frequency in Hz
       * @warning The new frequency can't be inferior to the the one set in the initialization step
      */
-     uint32_t changeFrequency(uint32_t frequency_update);
+     void setFrequency(uint32_t frequency_update);
 };
 
 #endif // PWMHAL_H_

--- a/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.h
@@ -36,24 +36,21 @@
 #include "adc.h"
 #include "hrtim_enum.h"
 
-
 /** Switch leg operation type.
  */
 typedef enum
 {
-	buck,
-	boost
+     buck,
+     boost
 } leg_operation_t;
 
 /** Inverter leg operation type.
  */
 typedef enum
 {
-	unipolar,
-	bipolar
+     unipolar,
+     bipolar
 } inverter_modulation_t;
-
-
 
 /**
  * @brief  Handles all pwm signals for the spin board
@@ -63,304 +60,302 @@ typedef enum
 class PwmHAL
 {
 public:
-	//HRTIM configuration
+     // HRTIM configuration
 
-    /**
-     * @brief     This function initializes a timing unit
-     *
-     * @param[in] pwmX    PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+     /**
+      * @brief     This function initializes a timing unit
+      *
+      * @param[in] pwmX    PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      */
+     void initUnit(hrtim_tu_number_t pwmX);
+
+     /**
+      * @brief     This fonction starts both outputs of the selected HRTIM channel
+      *
+      * @param[in] pwmX    PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      */
+     void startDualOutput(hrtim_tu_number_t pwmX);
+
+     /**
+      * @brief     This function stops both outputs of the selected HRTIM channel
+      *
+      * @param[in] pwmX    PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      */
+     void stopDualOutput(hrtim_tu_number_t pwmX);
+
+     /**
+      * @brief     This function starts only one output of the selected HRTIM channel
+      *
+      * @param[in] tu		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME, PWMF
+      * @param[in] output	output to disable - TIMING_OUTPUT1, TIMING_OUTPUT2
+      */
+     void startSingleOutput(hrtim_tu_number_t tu, hrtim_output_number_t output);
+
+     /**
+      * @brief     This function starts only one output of the selected HRTIM channel
+      *
+      * @param[in] tu		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME, PWMF
+      * @param[in] output	output to disable - TIMING_OUTPUT1, TIMING_OUTPUT2
+      */
+     void stopSingleOutput(hrtim_tu_number_t tu, hrtim_output_number_t output);
+
+     /**
+      * @brief     This function sets the modulation mode for a given PWM unit
+      *
+      * @param[in] pwmX    PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] modulation    PWM Modulation - Lft_aligned or UpDwn
+      *
+      * @warning this function must be called BEFORE initializing the selected timer
+      */
+     void setModulation(hrtim_tu_number_t pwmX, hrtim_cnt_t modulation);
+
+     /**
+      * @brief     This function sets the switch convention for a given PWM unit
+      * 			  i.e. you decide which one of the output of the timer can be controlled
+      * 			  with duty cycle.
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] convention    PWM Switch to be driven by the duty cycle. The other will be complementary - PWMx1 or PWMx2
+      *
+      * @warning this function must be called before the timer initialization
+      */
+     void setSwitchConvention(hrtim_tu_number_t pwmX, hrtim_switch_convention_t convention);
+
+     /**
+      * @brief     This function sets the frequency
+      *
+      * @param[in] value frequency in Hz
+      *
+      * @warning this function must be called BEFORE initialiazing any timing unit
+      */
+     void setFrequency(uint32_t value);
+
+     /**
+      * @brief     This function sets the dead time for the selected timing unit
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] rise_ns		rising edge dead time in ns
+      * @param[in] falling_ns	falling edge dead time in ns
+      *
+      * @warning use this function AFTER initializing the chosen timer
+      */
+     void setDeadTime(hrtim_tu_number_t pwmX, uint16_t rise_ns, uint16_t fall_ns);
+
+     /**
+      * @brief     This function sets the duty cycle for the selected timing unit
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] value			duty cycle value
+      */
+     void setDutyCycle(hrtim_tu_number_t pwmX, float32_t duty_cycle);
+
+     /**
+      * @brief     This function sets the phase shift in respect to timer A for the selected timing unit
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] shift			phase shift value ° between -360 and 360
+      *
+      * @warning use this function AFTER setting the frequency and initializing the chosen timer
+      */
+     void setPhaseShift(hrtim_tu_number_t pwmX, int16_t shift);
+
+     /**
+      * @brief     				This function sets a special pwm mode for voltage or current mode
+      *
+      * @param[in] pwmX	    	PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] mode    		PWM mode - VOLTAGE_MODE or CURRENT_MODE
+      *
+      * @warning this function must be called BEFORE initialiazing the selected timing unit
+      */
+     void setMode(hrtim_tu_number_t pwmX, hrtim_pwm_mode_t mode);
+
+     /**
+      * @brief     				This function returns the PWM mode (voltage or current mode)
+      *
+      * @param[in] pwmX	    	PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @return           		PWM mode - VOLTAGE_MODE or CURRENT_MODE
+      *
+      * @warning this function must be called before initialiazing a timing unit
+      */
+     hrtim_pwm_mode_t getMode(hrtim_tu_number_t pwmX);
+
+     /**
+      * @brief     				This function sets external event linked to the timing unit essential for the current mode
+      *
+      * @param[in] pwmX	    	PWM Unit 					 - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] eev    		external event trigger		 - EEV1,EEV2, EEV3, EEV3, EEV4, EEV5, EEV6, EEV7, EEV8, EEV9
+      *
+      * @warning this function must be called before initialiazing a timing unit
+      */
+     void setEev(hrtim_tu_number_t pwmX, hrtim_external_trigger_t eev);
+
+     /**
+      * @brief     				This function sets the external event linked to the timing unit used for the current mode
+      *
+      * @param[in] pwmX	    	PWM Unit 					 - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @return  		   		external event trigger		 - EEV1,EEV2, EEV3, EEV3, EEV4, EEV5, EEV6, EEV7, EEV8, EEV9
+      */
+     hrtim_external_trigger_t getEev(hrtim_tu_number_t pwmX);
+
+     /**
+      * @brief     This function returns the modulation type of the selected timing unit
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @return 					Lft_aligned or UpDwn (center aligned)
+      */
+     hrtim_cnt_t getModulation(hrtim_tu_number_t pwmX);
+
+     /**
+      * @brief     This function returns the switching convention of the selected timing unit
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @return 					PWMx1 (high side convention) or PWMx2 (low-side convention)
+      */
+     hrtim_switch_convention_t getSwitchConvention(hrtim_tu_number_t pwmX);
+
+     /**
+      * @brief     This function returns the period of the selected timing unit
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @return 					the period value in uint16
+      */
+     uint16_t getPeriod(hrtim_tu_number_t pwmX);
+
+     /**
+      * @brief     This function sets the PostScaler value for the selected timing unit
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] ps_ratio		post scaler ratio
+      *
+      * @warning   this function must be called after initialiazing a timing unit, and before
+      * 			   enabling the adc trigger
+      */
+     void setAdcTriggerPostScaler(hrtim_tu_number_t pwmX, uint32_t ps_ratio);
+
+     /**
+      * @brief     				This function sets the adc trigger linked to a timer unit
+      *
+      * @param[in] pwmX	    	PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] adc_trig    	adc trigger - ADCTRIG_1, ADCTRIG_2, ADCTRIG_3 et ADCTRIG_4
+      *
+      * @warning Call this function BEFORE enabling the adc trigger and AFTER initializing the selected timer
+      */
+     void setAdcTrigger(hrtim_tu_number_t pwmX, hrtim_adc_trigger_t adc_trig);
+
+     /**
+      * @brief     				This function returns the adc trigger linked to a timer unit
+      *
+      * @param[in] pwmX	    	PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @return    				adc trigger - ADCTRIG_1, ADCTRIG_2, ADCTRIG_3 et ADCTRIG_4
+      */
+     hrtim_adc_trigger_t getAdcTrigger(hrtim_tu_number_t pwmX, hrtim_adc_trigger_t adc_trig);
+
+     /**
+      * @brief     This function enables the adc trigger for the selected timing unit
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      *
+      * @warning  call this function only AFTER setting the adc trigger and initializing the chosen timer
+      */
+     void enableAdcTrigger(hrtim_tu_number_t tu_number);
+
+     /**
+      * @brief     This function disables the adc trigger for the selected timing unit
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      */
+     void disableAdcTrigger(hrtim_tu_number_t tu_number);
+
+     /**
+      * @brief     This function sets the comparator value at which the ADC is trigered
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] trig_val    	a value between 0 and 1
+      */
+     void setAdcTriggerInstant(hrtim_tu_number_t pwmX, float32_t trig_val);
+
+     /**
+      * @brief     				This function sets the adc trig rollover mode for the selected timer
+      *
+      * @param[in] pwmX    			PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] adc_edge_trigger  Rollover mode - EdgeTrigger_up, EdgeTrigger_down, EdgeTrigger_Both
+      *
+      * @warning this function must be called BEFORE initialiazing the selected timing unit
+      */
+     void setAdcEdgeTrigger(hrtim_tu_number_t pwmX, hrtim_adc_edgetrigger_t adc_edge_trigger);
+
+     /**
+      * @brief     				This function returns the adc trigger rollover mode for the selected timer
+      *
+      * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @return    			    Rollover mode - EdgeTrigger_up, EdgeTrigger_down, EdgeTrigger_Both
+      */
+     hrtim_adc_edgetrigger_t getAdcEdgeTrigger(hrtim_tu_number_t pwmX);
+
+     /**
+      * @brief     				This function sets the number of event which will be ignored between two events.
+      * 							ie. you divide the number of trigger in a fixed period. For example if decimation = 1,
+      * 							nothing changes but with decimation = 2 you have twice less adc trigger.
+      *
+      * @param[in] pwmX	    	PWM Unit 					 - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      * @param[in] decimation  	decimation/post-scaler		 - a number between 1 and 32
+      *
+      * @warning this function must be called AFTER initialiazing the selected timing unit
+      */
+     void setAdcDecimation(hrtim_tu_number_t pwmX, uint32_t decimation);
+
+     /**
+      * @brief     This function disables the interrupt on repetition counter
+      *
+      * @param[in] PWM_tu    	PWM Unit - TIMA, TIMB, TIMC, TIMD, TIME or TIMF
+      */
+     void disablePeriodEvnt(hrtim_tu_t PWM_tu);
+
+     /**
+      * @brief     This function sets the repetition counter to ISR period
+      *
+      * @param[in] PWM_tu    	PWM Unit - TIMA, TIMB, TIMC, TIMD, TIME or TIMF
+      * @param[in] repetition 	number of repetition before the interruption on repetition counter event
+      */
+     void setPeriodEvntRep(hrtim_tu_t PWM_tu, uint32_t repetition);
+
+     /**
+      * @brief     This function returns the repetition counter value
+      *
+      * @param[in] PWM_tu    	PWM Unit - TIMA, TIMB, TIMC, TIMD, TIME or TIMF
+      * @return 					repetition counter value
+      */
+     uint32_t getPeriodEvntRep(hrtim_tu_t PWM_tu);
+
+     /**
+      * @brief     This function configures the interrupt on repetition counter
+      *
+      * @param[in] PWM_tu    	PWM Unit - TIMA, TIMB, TIMC, TIMD, TIME or TIMF
+      * @param[in] repetition 	number of repetition before the interruption on repetition counter event
+      * @param[in] callback		function to call each interupt
+      */
+     void configurePeriodEvnt(hrtim_tu_t PWM_tu, uint32_t repetition, hrtim_callback_t callback);
+
+     /**
+      * @brief     This function enables the interrupt on repetition counter
+      *
+      * @param[in] PWM_tu    	PWM Unit - TIMA, TIMB, TIMC, TIMD, TIME or TIMF
+      */
+     void enablePeriodEvnt(hrtim_tu_t PWM_tu);
+
+     /**
+      * @brief     				This function returns the period in µs of the selected timer
+      *
+      * @param[in] pwmX    	PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
+      */
+     uint32_t getPeriodUs(hrtim_tu_number_t pwmX);
+
+     /**
+      * @brief Change the frequency/period after it has been initialized.
+      * @param[in] frequency_update The new frequency in Hz
+      * @warning The new frequency can't be inferior to the the one set in the initialization step
      */
-	void initUnit(hrtim_tu_number_t pwmX);
-
-    /**
-     * @brief     This fonction starts both outputs of the selected HRTIM channel
-     *
-     * @param[in] pwmX    PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     */
-    void startDualOutput(hrtim_tu_number_t pwmX);
-
-
-    /**
-     * @brief     This function stops both outputs of the selected HRTIM channel
-     *
-     * @param[in] pwmX    PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     */
-    void stopDualOutput(hrtim_tu_number_t pwmX);
-
-
-	/**
-     * @brief     This function starts only one output of the selected HRTIM channel
-     *
-     * @param[in] tu		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME, PWMF
-     * @param[in] output	output to disable - TIMING_OUTPUT1, TIMING_OUTPUT2
-     */
-    void startSingleOutput(hrtim_tu_number_t tu, hrtim_output_number_t output);
-
-	/**
-     * @brief     This function starts only one output of the selected HRTIM channel
-     *
-     * @param[in] tu		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME, PWMF
-     * @param[in] output	output to disable - TIMING_OUTPUT1, TIMING_OUTPUT2
-     */
-    void stopSingleOutput(hrtim_tu_number_t tu, hrtim_output_number_t output);
-
-    /**
-     * @brief     This function sets the modulation mode for a given PWM unit
-     *
-     * @param[in] pwmX    PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] modulation    PWM Modulation - Lft_aligned or UpDwn
-     *
-     * @warning this function must be called BEFORE initializing the selected timer
-     */
-	void setModulation(hrtim_tu_number_t pwmX, hrtim_cnt_t modulation);
-
-
-	/**
-     * @brief     This function sets the switch convention for a given PWM unit
-     * 			  i.e. you decide which one of the output of the timer can be controlled
-     * 			  with duty cycle.
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] convention    PWM Switch to be driven by the duty cycle. The other will be complementary - PWMx1 or PWMx2
-     *
-     * @warning this function must be called before the timer initialization
-     */
-    void setSwitchConvention(hrtim_tu_number_t pwmX, hrtim_switch_convention_t convention);
-
-    /**
-     * @brief     This function sets the frequency
-     *
-     * @param[in] value frequency in Hz
-     *
-     * @warning this function must be called BEFORE initialiazing any timing unit
-     */
-	void setFrequency(uint32_t value);
-
-    /**
-     * @brief     This function sets the dead time for the selected timing unit
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] rise_ns		rising edge dead time in ns
-     * @param[in] falling_ns	falling edge dead time in ns
-     *
-     * @warning use this function AFTER initializing the chosen timer
-     */
-	void setDeadTime(hrtim_tu_number_t pwmX, uint16_t rise_ns, uint16_t fall_ns);
-
-	/**
-     * @brief     This function sets the duty cycle for the selected timing unit
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] value			duty cycle value
-     */
-    void setDutyCycle(hrtim_tu_number_t pwmX, float32_t duty_cycle);
-
-    /**
-     * @brief     This function sets the phase shift in respect to timer A for the selected timing unit
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] shift			phase shift value ° between -360 and 360
-     *
-     * @warning use this function AFTER setting the frequency and initializing the chosen timer
-     */
-	void setPhaseShift(hrtim_tu_number_t pwmX, int16_t shift);
-
-    /**
-     * @brief     				This function sets a special pwm mode for voltage or current mode
-     *
-     * @param[in] pwmX	    	PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] mode    		PWM mode - VOLTAGE_MODE or CURRENT_MODE
-     *
-     * @warning this function must be called BEFORE initialiazing the selected timing unit
-     */
-	void setMode(hrtim_tu_number_t pwmX, hrtim_pwm_mode_t mode);
-
-    /**
-     * @brief     				This function returns the PWM mode (voltage or current mode)
-     *
-     * @param[in] pwmX	    	PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @return           		PWM mode - VOLTAGE_MODE or CURRENT_MODE
-     *
-     * @warning this function must be called before initialiazing a timing unit
-     */
-	hrtim_pwm_mode_t getMode(hrtim_tu_number_t pwmX);
-
-    /**
-     * @brief     				This function sets external event linked to the timing unit essential for the current mode
-     *
-     * @param[in] pwmX	    	PWM Unit 					 - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] eev    		external event trigger		 - EEV1,EEV2, EEV3, EEV3, EEV4, EEV5, EEV6, EEV7, EEV8, EEV9
-     *
-     * @warning this function must be called before initialiazing a timing unit
-     */
-	void setEev(hrtim_tu_number_t pwmX, hrtim_external_trigger_t eev);
-
-    /**
-     * @brief     				This function sets the external event linked to the timing unit used for the current mode
-     *
-     * @param[in] pwmX	    	PWM Unit 					 - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @return  		   		external event trigger		 - EEV1,EEV2, EEV3, EEV3, EEV4, EEV5, EEV6, EEV7, EEV8, EEV9
-     */
-	hrtim_external_trigger_t getEev(hrtim_tu_number_t pwmX);
-
-    /**
-     * @brief     This function returns the modulation type of the selected timing unit
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @return 					Lft_aligned or UpDwn (center aligned)
-     */
-	hrtim_cnt_t getModulation(hrtim_tu_number_t pwmX);
-
-    /**
-     * @brief     This function returns the switching convention of the selected timing unit
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @return 					PWMx1 (high side convention) or PWMx2 (low-side convention)
-     */
-	hrtim_switch_convention_t getSwitchConvention(hrtim_tu_number_t pwmX);
-
-    /**
-     * @brief     This function returns the period of the selected timing unit
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @return 					the period value in uint16
-     */
-    uint16_t getPeriod(hrtim_tu_number_t pwmX);
-
-    /**
-     * @brief     This function sets the PostScaler value for the selected timing unit
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] ps_ratio		post scaler ratio
-     *
-     * @warning   this function must be called after initialiazing a timing unit, and before
-     * 			   enabling the adc trigger
-     */
-	void setAdcTriggerPostScaler(hrtim_tu_number_t pwmX, uint32_t ps_ratio);
-
-
-    /**
-     * @brief     				This function sets the adc trigger linked to a timer unit
-     *
-     * @param[in] pwmX	    	PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] adc_trig    	adc trigger - ADCTRIG_1, ADCTRIG_2, ADCTRIG_3 et ADCTRIG_4
-     *
-     * @warning Call this function BEFORE enabling the adc trigger and AFTER initializing the selected timer
-     */
-	void setAdcTrigger(hrtim_tu_number_t pwmX, hrtim_adc_trigger_t adc_trig);
-
-
-    /**
-     * @brief     				This function returns the adc trigger linked to a timer unit
-     *
-     * @param[in] pwmX	    	PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @return    				adc trigger - ADCTRIG_1, ADCTRIG_2, ADCTRIG_3 et ADCTRIG_4
-     */
-	hrtim_adc_trigger_t getAdcTrigger(hrtim_tu_number_t pwmX, hrtim_adc_trigger_t adc_trig);
-
-    /**
-     * @brief     This function enables the adc trigger for the selected timing unit
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     *
-     * @warning  call this function only AFTER setting the adc trigger and initializing the chosen timer
-     */
-	void enableAdcTrigger(hrtim_tu_number_t tu_number);
-
-    /**
-     * @brief     This function disables the adc trigger for the selected timing unit
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     */
-   void disableAdcTrigger(hrtim_tu_number_t tu_number);
-
-    /**
-     * @brief     This function sets the comparator value at which the ADC is trigered
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] trig_val    	a value between 0 and 1
-     */
-	void setAdcTriggerInstant(hrtim_tu_number_t pwmX, float32_t trig_val);
-
-    /**
-     * @brief     				This function sets the adc trig rollover mode for the selected timer
-     *
-     * @param[in] pwmX    			PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] adc_edge_trigger  Rollover mode - EdgeTrigger_up, EdgeTrigger_down, EdgeTrigger_Both
-     *
-     * @warning this function must be called BEFORE initialiazing the selected timing unit
-     */
-	void setAdcEdgeTrigger(hrtim_tu_number_t pwmX, hrtim_adc_edgetrigger_t adc_edge_trigger);
-
-    /**
-     * @brief     				This function returns the adc trigger rollover mode for the selected timer
-     *
-     * @param[in] pwmX    		PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @return    			    Rollover mode - EdgeTrigger_up, EdgeTrigger_down, EdgeTrigger_Both
-     */
-    hrtim_adc_edgetrigger_t getAdcEdgeTrigger(hrtim_tu_number_t pwmX);
-
-    /**
-     * @brief     				This function sets the number of event which will be ignored between two events.
-     * 							ie. you divide the number of trigger in a fixed period. For example if decimation = 1,
-     * 							nothing changes but with decimation = 2 you have twice less adc trigger.
-     *
-     * @param[in] pwmX	    	PWM Unit 					 - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     * @param[in] decimation  	decimation/post-scaler		 - a number between 1 and 32
-     *
-     * @warning this function must be called AFTER initialiazing the selected timing unit
-     */
-	void setAdcDecimation(hrtim_tu_number_t pwmX,  uint32_t decimation);
-
-	/**
-     * @brief     This function disables the interrupt on repetition counter
-     *
-     * @param[in] PWM_tu    	PWM Unit - TIMA, TIMB, TIMC, TIMD, TIME or TIMF
-     */
-    void disablePeriodEvnt(hrtim_tu_t PWM_tu);
-
-    /**
-     * @brief     This function sets the repetition counter to ISR period
-     *
-     * @param[in] PWM_tu    	PWM Unit - TIMA, TIMB, TIMC, TIMD, TIME or TIMF
-     * @param[in] repetition 	number of repetition before the interruption on repetition counter event
-     */
-	void setPeriodEvntRep(hrtim_tu_t PWM_tu, uint32_t repetition);
-
-    /**
-     * @brief     This function returns the repetition counter value
-     *
-     * @param[in] PWM_tu    	PWM Unit - TIMA, TIMB, TIMC, TIMD, TIME or TIMF
-     * @return 					repetition counter value
-     */
-    uint32_t getPeriodEvntRep(hrtim_tu_t PWM_tu);
-
-    /**
-     * @brief     This function configures the interrupt on repetition counter
-     *
-     * @param[in] PWM_tu    	PWM Unit - TIMA, TIMB, TIMC, TIMD, TIME or TIMF
-     * @param[in] repetition 	number of repetition before the interruption on repetition counter event
-     * @param[in] callback		function to call each interupt
-     */
-	void configurePeriodEvnt(hrtim_tu_t PWM_tu, uint32_t repetition, hrtim_callback_t callback);
-
-    /**
-     * @brief     This function enables the interrupt on repetition counter
-     *
-     * @param[in] PWM_tu    	PWM Unit - TIMA, TIMB, TIMC, TIMD, TIME or TIMF
-     */
-	void enablePeriodEvnt(hrtim_tu_t PWM_tu);
-
-    /**
-     * @brief     				This function returns the period in µs of the selected timer
-     *
-     * @param[in] pwmX    	PWM Unit - PWMA, PWMB, PWMC, PWMD, PWME or PWMF
-     */
-    uint32_t getPeriodUs(hrtim_tu_number_t pwmX);
-
-
+     uint32_t changeFrequency(uint32_t frequency_update);
 };
-
-
 
 #endif // PWMHAL_H_

--- a/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.h
+++ b/zephyr/modules/owntech_spin_api/zephyr/src/PwmHAL.h
@@ -127,7 +127,8 @@ public:
       * @param[in] init_frequency frequency in Hz
       *
       * @warning this function must be called BEFORE initialiazing any timing unit. 
-      *          the frequency initialized becomes the MINIMUM possible.
+      *          the frequency initialized becomes the MINIMUM possible. 
+      *          use it BEFORE initialization of the timing unit.
       */
      void initFrequency(uint32_t init_frequency);
 
@@ -365,6 +366,7 @@ public:
       * @brief Change the frequency/period after it has been initialized.
       * @param[in] frequency_update The new frequency in Hz
       * @warning The new frequency can't be inferior to the the one set in the initialization step
+      *          Use it AFTER the initialization of the timing unit.
      */
      void setFrequency(uint32_t frequency_update);
 };


### PR DESCRIPTION
# Features added

There are now two new functions in the PWM API, `initFrequency` and `setFrequency`.

## initFrequency 

The goal of this function is to set an initial frequency to compute HRTIM prescaler (which can't be changed after that). There are two way to use it : 

```cpp
spin.pwm.initFrequency(20000);
spin.pwm.initUnit(PWMA);
``` 
This will set PWMA to 20kHz frequency, and it will also be the minimum frequency possible.

```cpp
spin.pwm.initFrequency(200000, 20000);
spin.pwm.initUnit(PWMA);
```

This will set PWMA to 200kHz and make 20kHz the minimum frequency possible, meaning that we can change the frequency to 20kHz without problem.

## setFrequency

This function will update the frequency, but only up to the minimum frequency possible set in `iniFrequency`. Update the frequency keep the duty cycle and phase shift the same. 

# Issues solved 

## Dead time which can't go above 300 ns

close #51 

The dead time can now go above 300ns, we can also update the dead time without stopping the PWM. 

## Phase shift problem 

close #53 

Correct the problem of phase shift in center aligned. 

