### PR TITLE
Adding platformio.ini based BOARD and SHIELD definition supporting Version numbers

### DIFF
--- a/owntech/pio_extra.ini
+++ b/owntech/pio_extra.ini
@@ -53,6 +53,7 @@ extra_scripts =
     pre:owntech/scripts/pre_target_examples.py
     pre:owntech/scripts/pre_expert_mode.py
     pre:owntech/scripts/pre_stlink.py
+    pre:owntech/scripts/pre_version.py
 
 ###
 

--- a/owntech/pio_extra.ini
+++ b/owntech/pio_extra.ini
@@ -86,6 +86,7 @@ extra_scripts =
     pre:owntech/scripts/pre_recovery.py
     pre:owntech/scripts/pre_usb.py
     pre:owntech/scripts/plot/pre_plot_records.py
+    pre:owntech/scripts/pre_version.py
 
 ###
 

--- a/owntech/scripts/pre_version.py
+++ b/owntech/scripts/pre_version.py
@@ -1,0 +1,71 @@
+import os
+Import("env")
+
+# Retrieve project options
+# version default is empty
+# shield default is empty
+board = env.GetProjectOption("board")
+version = env.GetProjectOption("board_version", "")
+shield = env.GetProjectOption("board_shield", "")
+shield_version = env.GetProjectOption("board_shield_version", "")
+
+cmake_file_path = os.path.join('.', "zephyr", "CMakeLists.txt")
+
+def modify_cmake_file(file_path, board_name, bversion, shield_name, sversion):
+    # Construct the full names with versions if provided
+    full_board_name = f"{board_name}@{bversion}" if bversion else board_name
+    full_shield_name = f"{shield_name}_v{sversion}" if sversion else shield_name
+
+    try:
+        # Read the CMakeLists.txt file
+        with open(file_path, 'r') as file:
+            lines = file.readlines()
+    except FileNotFoundError:
+        print(f"Error: The file {file_path} was not found.")
+        return
+    except IOError:
+        print(f"Error: An IOError occurred while trying to read the file {file_path}.")
+        return
+
+    # Flags to check if the directives were found
+    board_set = False
+    shield_set = False
+    board_index = -1
+
+    # Modify the lines accordingly
+    new_lines = []
+    for i, line in enumerate(lines):
+        if line.strip().startswith('set(BOARD '):
+            new_lines.append(f'set(BOARD {full_board_name})\n')
+            board_set = True
+            board_index = i
+        elif line.strip().startswith('set(SHIELD '):
+            if shield_name:  # Only add the shield line if shield_name is not empty
+                new_lines.append(f'set(SHIELD {full_shield_name})\n')
+                shield_set = True
+            # Do not add the existing shield line if shield_name is empty
+        else:
+            new_lines.append(line)
+
+    # Add the directives if they were not found
+    if not board_set:
+        new_lines.append(f'set(BOARD {full_board_name})\n')
+        print(f"Added 'set(BOARD {full_board_name})' to {file_path}.")
+        board_index = len(new_lines) - 1
+
+    if shield_name and not shield_set:
+        # Insert shield line right after the board line
+        if board_index != -1:
+            new_lines.insert(board_index + 1, f'set(SHIELD {full_shield_name})\n')
+        else:
+            new_lines.append(f'set(SHIELD {full_shield_name})\n')
+        print(f"Added 'set(SHIELD {full_shield_name})' to {file_path}.")
+
+    try:
+        # Write the modified lines back to the file
+        with open(file_path, 'w') as file:
+            file.writelines(new_lines)
+    except IOError:
+        print(f"Error: An IOError occurred while trying to write to the file {file_path}.")
+
+modify_cmake_file(cmake_file_path, board, version, shield, shield_version)

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,11 +23,23 @@ libdeps_dir = owntech/lib
 # Do not edit or remove the following line
 [env]
 
-# Define board
+# Defines board
 # Supported boards:
 # - spin (default)
 # - nucleo_g474re
 board = spin
+# Defines board version
+# Supported version:
+# - 1_0_0
+# - 1_1_0
+# board_version = 1_2_0 
+# Defines shield 
+# Supported shields:
+# - twist
+board_shield = twist
+# Defines shield version
+# Refers to shield overlay to set shield version.
+board_shield_version = 1_4_1 
 
 # Compiler settings
 build_flags =

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -71,17 +71,28 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party_modules)
   list(APPEND ZEPHYR_EXTRA_MODULES ${THIRDPARTY})
 endif()
 
-# Board
+# Add OwnTech Board repository
+# Board repository contains all boards and shields dts overlays and 
+# config files required for the build
 list(APPEND BOARD_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 
-# Enable Twist shield
-set(SHIELD twist)
+# Set Board - It will be changed automatically by pre_version.py
+# Use platformio.ini and define board and board_version
+# board_version is concatenated to board with an extra "@"
+# "@" is the default versionning notation for zephyr build system. 
 
+# Set Shield - It will be changed automatically by pre_version.py
+# Use platformio.ini and define board_shield and board_shield_version
+# board_shield_version is concatenated to board_shield. 
+
+set(BOARD spin)
+set(SHIELD twist_v1_4_1)
+
+set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "")
 # Configure Zephyr
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(owntech_power_api)
-
 target_sources(app PRIVATE ../src/main.cpp)
 zephyr_include_directories(../src)

--- a/zephyr/boards/shields/twist/Kconfig.shield
+++ b/zephyr/boards/shields/twist/Kconfig.shield
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: LGPL-2.1
 
 config SHIELD_TWIST
-	def_bool $(shields_list_contains,twist)
+	def_bool $(shields_list_contains,twist_v1_4_1) || \
+				$(shields_list_contains,twist)

--- a/zephyr/boards/shields/twist/twist_v1_4_1.overlay
+++ b/zephyr/boards/shields/twist/twist_v1_4_1.overlay
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023-2024 OwnTech.
+ *
+ * SPDX-License-Identifier: LGPL-2.1
+ */
+
+#include "can-standby-switch.dtsi"
+#include "adc-channels.dtsi"
+#include "ngnd.dtsi"
+#include "pwm_legs.dtsi"
+#include "safety-thresholds.dtsi"
+
+&ngnd {
+	status = "okay";
+};
+
+&v1low {
+	status = "okay";
+};
+
+&v2low {
+	status = "okay";
+};
+
+&vhigh {
+	status = "okay";
+};
+
+&i1low {
+	status = "okay";
+};
+
+&i2low {
+	status = "okay";
+};
+
+&ihigh {
+	status = "okay";
+};
+
+
+&leg1 {
+	status = "okay";
+};
+
+&leg2 {
+	status = "okay";
+};
+
+&v2lowtd{
+	status = "okay";
+};
+
+&vhightd{
+	status = "okay";
+};
+
+&i1lowtd{
+	status = "okay";
+};
+
+&i2lowtd{
+	status = "okay";
+};
+
+&ihightd{
+	status = "okay";
+};
+
+&temptd{
+	status = "disabled";
+};
+
+&extratd{
+	status = "disabled";
+};
+
+&analogtd{
+	status = "disabled";
+};


### PR DESCRIPTION
Following last week findings with @martinjaeger : 

This PR adds supports for versionning using cmake calls. 
The PR adds a script that retrieves value from platformio.ini and add the config to the Cmakefile automatically. 

From that base we can add version based overlays for pinout fixes. 
It also open the door to a generic implementation of what is now called "twistAPI". 
Now the dts fragment of any shield can be added only using platformio.ini hence the next missing block is proper
dts based config on driver side. 

I do call your attention on one of my wonders: 
I've changed the way CONFIG_SHIELD_TWIST is set, so it "multiplexes" all versions of twist. 
Should we instead create CONFIG_SHIELD_TWIST_141 ? (version based)
Should we add a separate CONFIG_SHIELD_VERSION with an integer ? 
Maybe we don't even need Kconfig to retrieve the version ? 
Retrieving the version would be nice for monitoring purposes -> adding the shield name to the boot banneer or to a 
Can data object. 


