### PR TITLE
Update to Zephyr v3.6

### DIFF
--- a/owntech/pio_extra.ini
+++ b/owntech/pio_extra.ini
@@ -10,10 +10,10 @@ boards_dir = owntech/boards
 [env]
 
 # Platform and OS
-platform = ststm32@17.0.0
+platform = ststm32@17.3.0
 framework = zephyr
 
-platform_packages = 
+platform_packages =
     tool-openocd
     tool-dfuutil
 

--- a/zephyr/boards/arm/spin/spin.dts
+++ b/zephyr/boards/arm/spin/spin.dts
@@ -27,7 +27,7 @@
 		zephyr,console = &cdc_acm_uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,can-primary = &can1;
+		zephyr,can-primary = &fdcan1;
 		zephyr,boot-mode = &retention0;
 	};
 
@@ -214,14 +214,12 @@ zephyr_udc0: &usb {
 
 // CAN
 
-&can1 {
+&fdcan1 {
 	pinctrl-0 = <&fdcan1_rx_pb8 &fdcan1_tx_pb9>;
 	pinctrl-names = "default";
 	bus-speed = <500000>;
-	sjw = <1>;
 	sample-point = <875>;
 	bus-speed-data = <500000>;
-	sjw-data = <1>;
 	sample-point-data = <875>;
 	status = "okay";
 };
@@ -231,9 +229,12 @@ zephyr_udc0: &usb {
 /*********/
 
 &timers4 {
-	pinctrl-0 = <&tim4_etr_pb3 &tim4_ch1_pb6 &tim4_ch2_pb7>;
-	pinctrl-names = "incremental_encoder";
 	status = "okay";
+
+	encoder {
+		pinctrl-0 = <&tim4_etr_pb3 &tim4_ch1_pb6 &tim4_ch2_pb7>;
+		pinctrl-names = "incremental_encoder";
+	};
 };
 
 &timers6 {
@@ -263,30 +264,40 @@ zephyr_udc0: &usb {
 &adc1 {
 	pinctrl-0 = <&adc1_in6_pc0 &adc1_in7_pc1 &adc1_in8_pc2 &adc1_in9_pc3>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 
 &adc2 {
 	pinctrl-0 = <&adc2_in1_pa0 &adc2_in2_pa1 &adc2_in3_pa6 &adc2_in5_pc4>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 
 &adc3 {
 	pinctrl-0 = <&adc3_in1_pb1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 
 &adc4 {
 	pinctrl-0 = <&adc4_in5_pb15>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 
 &adc5 {
 	pinctrl-0 = <&adc5_in1_pa8 &adc5_in2_pa9>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/zephyr/boards/shields/twist/can-standby-switch.dtsi
+++ b/zephyr/boards/shields/twist/can-standby-switch.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 OwnTech.
+ * Copyright (c) 2022-2024 OwnTech.
  *
  * SPDX-License-Identifier: LGPL-2.1
  */
@@ -9,7 +9,6 @@
 		compatible = "gpio-device";
 		can-standby-gpio-pin {
 			gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
-			label = "CAN Standby output";
 		};
 	};
 };

--- a/zephyr/boards/shields/twist/ngnd.dtsi
+++ b/zephyr/boards/shields/twist/ngnd.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 OwnTech.
+ * Copyright (c) 2022-2024 OwnTech.
  *
  * SPDX-License-Identifier: LGPL-2.1
  */
@@ -9,7 +9,6 @@
 		compatible = "gpio-device";
 		ngnd-gpio-pin {
 			gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
-			label = "Neutral to GND shunt";
 		};
 	};
 };

--- a/zephyr/dts/adc.dtsi
+++ b/zephyr/dts/adc.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 OwnTech.
+ * Copyright (c) 2022-2024 OwnTech.
  *
  * SPDX-License-Identifier: LGPL-2.1
  *
@@ -15,7 +15,6 @@
 			clocks = < &rcc STM32_CLOCK_BUS_AHB2 0x00004000 >;
 			interrupts = < 18 0x0 >;
 			status = "disabled";
-			label = "ADC_3";
 			#io-channel-cells = < 0x1 >;
 		};
 
@@ -25,7 +24,6 @@
 			clocks = < &rcc STM32_CLOCK_BUS_AHB2 0x00004000 >;
 			interrupts = < 18 0x0 >;
 			status = "disabled";
-			label = "ADC_4";
 			#io-channel-cells = < 0x1 >;
 		};
 
@@ -35,7 +33,6 @@
 			clocks = < &rcc STM32_CLOCK_BUS_AHB2 0x00004000 >;
 			interrupts = < 18 0x0 >;
 			status = "disabled";
-			label = "ADC_5";
 			#io-channel-cells = < 0x1 >;
 		};
 	};

--- a/zephyr/dts/bindings/gpio-device.yaml
+++ b/zephyr/dts/bindings/gpio-device.yaml
@@ -8,7 +8,3 @@ child-binding:
     gpios:
       type: phandle-array
       required: true
-    label:
-      required: true
-      type: string
-      description: Human-readable string describing the pin function

--- a/zephyr/dts/hrtim.dtsi
+++ b/zephyr/dts/hrtim.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 OwnTech.
+ * Copyright (c) 2022-2024 OwnTech.
  *
  * SPDX-License-Identifier: LGPL-2.1
  */
@@ -17,7 +17,6 @@
 					  "timd", "time", "flt", "timf";
 			st,prescaler = <0>;
 			status = "okay";
-			label = "HRTIM_1";
 			outputs {
 				compatible = "hrtim";
 				pinctrl-0 = <&hrtim1_cha1_pa8 &hrtim1_cha2_pa9

--- a/zephyr/modules/owntech_data_api/zephyr/src/shield_channels.cpp
+++ b/zephyr/modules/owntech_data_api/zephyr/src/shield_channels.cpp
@@ -187,7 +187,7 @@ static void _adc_channels_build_available_channels_lists()
 					{
 						float32_t gain   = data_conversion_get_parameter(dt_channels_props[dt_channel_index].adc_number, dt_channels_props[dt_channel_index].channel_number, 1);
 						float32_t offset = data_conversion_get_parameter(dt_channels_props[dt_channel_index].adc_number, dt_channels_props[dt_channel_index].channel_number, 2);
-						printk("    Conversion type is linear, with gain=%f and offset=%f\n", gain, offset);
+						printk("    Conversion type is linear, with gain=%f and offset=%f\n", (double)gain, (double)offset);
 					}
 					break;
 				}
@@ -368,7 +368,7 @@ static float32_t _shield_channels_get_calibration_coefficients(const char* physi
 		parameterCoefficient = atof(line);
 
 		// Get confirmation
-		printk("%s %s applied will be : %f\n", physicalParameter, gainOrOffset, parameterCoefficient);
+		printk("%s %s applied will be : %f\n", physicalParameter, gainOrOffset, (double)parameterCoefficient);
 		printk("Press y to validate, any other character to retype the %s \n", gainOrOffset);
 		received_char = console_getchar();
 


### PR DESCRIPTION
PR #55 by @martinjaeger proposed to update to Zephyr 3.5.
However, according to my previous tests, 3.5 introduced some regressions in KConfig variables that were fixed in 3.6.
This PR is based on my previous test branch improved with @martinjaeger PR, and proposes to supersede it.