### PR TITLE
Add venv Python package requirement to the list of required software

### DIFF
--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -23,7 +23,9 @@ Before we start, make sure your machine meets all the requirements below.
 
         - **Git:** If you do not have git installed, get it here [git for Linux](https://git-scm.com/download/linux)
         - **Python3:** If you do not have python3 installed, get it here [Python3 Installers](https://docs.python-guide.org/starting/install3/linux/)
-          - Your Python installation should include the `venv` package which is **required** by PlatformIO. If using the system Python (`/usr/bin/python3`) on a Debian or Ubuntu system, you can install it with `$ sudo apt install python3-venv`.
+          - Warning: some Linux distributions such as Debian and Ubuntu don't install the [venv](https://docs.python.org/3/library/venv.html) module by default
+            even though it is part of the Python Standard Library.
+            In particular, if using the system Python (`/usr/bin/python3`) on a Debian or Ubuntu system, make sure that the `python3-venv` package is installed.
         - **CMake:** If you do not have CMake installed, get it here [CMake Installer](https://cmake.org/download/)
         - 64 bit linux installation
         - **Internet connection**

--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -23,6 +23,7 @@ Before we start, make sure your machine meets all the requirements below.
 
         - **Git:** If you do not have git installed, get it here [git for Linux](https://git-scm.com/download/linux)
         - **Python3:** If you do not have python3 installed, get it here [Python3 Installers](https://docs.python-guide.org/starting/install3/linux/)
+          - Your Python installation should include the `venv` package which is **required** by PlatformIO. If using the system Python (`/usr/bin/python3`) on a Debian or Ubuntu system, you can install it with `$ sudo apt install python3-venv`.
         - **CMake:** If you do not have CMake installed, get it here [CMake Installer](https://cmake.org/download/)
         - 64 bit linux installation
         - **Internet connection**
@@ -84,13 +85,6 @@ In Visual Studio code, on the left side menu, click on PlatformIO icon ! (1)
 
 !!! tip   "Pro tip"
     if the alien icon does not show up spontaneously, wait for a few more seconds, then press F1 key and type platformio home.
-
-!!! info
-    === "Linux"
-        If you are on linux and PlatformIO do not find the python path, you can launch the following command :
-        ```
-        sudo apt install python3-venv
-        ```
 
 ### Step 5 - Clone our Core repository
 In PlatformIO, select "Clone Git Project ".


### PR DESCRIPTION
I got hit by the absence of `venv` Python package which blocks the proper install of Platform IO on Linux (Ubuntu 22.04). See the forum discussion [PlatformIO IDE can’t find Python interpreter on Linux](https://community.platformio.org/t/platformio-ide-cant-find-python-interpreter-on-linux/24262). Notice that [their doc](https://docs.platformio.org/en/latest/integration/ide/vscode.html#installation) is below truth:

> Linux Users: To ensure a smooth experience with PlatformIO, it is essential to have the [python3-venv](https://github.com/platformio/platformio-core-installer/issues/85) package installed on your system. 

but it's not about smooth experience: it just blocks the install of PlatformIO core!

In the present state of the doc, this is mentioned at Step 4 "Step 4 - Open PlatformIO in VSCode" https://docs.owntech.org/core/docs/environment_setup/#step-4-open-platformio-in-vscode. 

I suggest instead to move it up to the software requirements.