### PR TITLE
add pip to software requirements for Linux

### DIFF
--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -23,9 +23,11 @@ Before we start, make sure your machine meets all the requirements below.
 
         - **Git:** If you do not have git installed, get it here [git for Linux](https://git-scm.com/download/linux)
         - **Python3:** If you do not have python3 installed, get it here [Python3 Installers](https://docs.python-guide.org/starting/install3/linux/)
-          - Warning: some Linux distributions such as Debian and Ubuntu don't install the [venv](https://docs.python.org/3/library/venv.html) module by default
-            even though it is part of the Python Standard Library.
-            In particular, if using the system Python (`/usr/bin/python3`) on a Debian or Ubuntu system, make sure that the `python3-venv` package is installed.
+            - The [pip](https://pip.pypa.io/en/stable/) package installer is needed. If using the system Python, `pip` may not be installed by default.
+              See [Installing pip with Linux Package Managers](https://packaging.python.org/en/latest/guides/installing-using-linux-tools/).
+            - Warning: some Linux distributions such as Debian and Ubuntu don't install the [venv](https://docs.python.org/3/library/venv.html) module by default
+              even though it is part of the Python Standard Library.
+              In particular, if using the system Python (`/usr/bin/python3`) on a Debian or Ubuntu system, make sure that the `python3-venv` package is installed.
         - **CMake:** If you do not have CMake installed, get it here [CMake Installer](https://cmake.org/download/)
         - 64 bit linux installation
         - **Internet connection**


### PR DESCRIPTION
this is again (after PR https://github.com/owntech-foundation/Core/pull/75) a change in the software requirements after getting hit by another missing Python dependency: pip.

Compared to `venv` in PR #75, `pip` is not part of the standard library but is provided in many installation packages (see https://pip.pypa.io/en/stable/installation/). However, again, it's not by default at least on Ubuntu 22.04.

As a side change: I've fixed the indentation of the sublist.