### PR TITLE
More minor edits to the Environment Setup documentation (#79)

### DIFF
--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -1,5 +1,6 @@
 
-If you use or wish to use Visual Studio Code, follow this tutorial to set up your work environment. It will use a “Blinky” (blinking LED) example which requires no other hardware than you OwnTech board.
+If you use or wish to use Visual Studio Code, follow this tutorial to set up your work environment.
+It will use a “Blinky” (blinking LED) example which requires no other hardware than your OwnTech board.
 
 
 ## Requirements
@@ -30,7 +31,7 @@ Before we start, make sure your machine meets all the requirements below.
               Warning if using the system Python: although `venv` is part of the Python Standard Library, some Linux distributions such as Debian and Ubuntu don't install it by default.
               In that case, make sure that the `python3-venv` package is installed.
         - **CMake:** If you do not have CMake installed, get it here [CMake Installer](https://cmake.org/download/)
-        - 64 bit linux installation
+        - 64 bit Linux distribution
         - Write permission for the serial port (`/dev/ttyACM0`): See PlatformIO documentation which provides a [udev rules file](https://docs.platformio.org/en/latest/core/installation/udev-rules.html)
         - **Internet connection**
 
@@ -40,12 +41,12 @@ Before we start, make sure your machine meets all the requirements below.
 To use OwnTech's system, we will use:
 
 * **Visual Studio Code** - The platform or Integrated Development Environment we will use to write code.
-* **PlatformIO** - A Visual Studio Code plugin that is a toolbox for microcontrollers
+* **PlatformIO** - A Visual Studio Code extension that is a toolbox for microcontrollers
 
 !!! info "Required Disk Space"
     Make sure that you have more than 2GB on your hard drive so that PlatformIO can download all the required files without issues.
 
-Here is how to setup the work environment:
+Here is how to set up this environment.
 
 ### Step 1 - Empty folder
 
@@ -72,9 +73,10 @@ An overview of VS Code user interface is available in their official [Get Starte
 Launch Visual Studio Code.
 
 In the “Activity Bar”, located on the far left-hand side, click on the Extensions icon (1)
-{ .annotate } to open the VS Code Extensions manager in the Primary Side Bar.
+to open the VS Code Extensions manager in the Primary Side Bar.
+{ .annotate }
 
-1. The icon looks like this: ![extension_icon](images/icon-extension.png)
+1. The VS Code Extensions manager icon looks like this: ![extension_icon](images/icon-extension.png)
 
 Using the search box in the Extensions Marketplace, search for the “PlatformIO IDE” extension and install it.
 
@@ -82,8 +84,8 @@ Finally, restart Visual Studio Code when you are prompted to do so.
 
 ![PlatformIO installation](images/fig1-platformio_installation.png)
 
-Once installed, you should see that PlatformIO has appended its “alien head” icon (1)
-{ .annotate } to the Activity Bar.
+Once installed, you should see that PlatformIO has appended its “alien head” icon (1) to the Activity Bar.
+{ .annotate }
 
 1. The PlatformIO icon looks like this: ![platformio_icon](images/icon-platformio.png)
 
@@ -103,7 +105,7 @@ to open PlatformIO in the Primary Side Bar. It should contain:
 ### Step 5 - Clone our Core repository
 
 In PlatformIO's “Quick Access” view, select the “Miscelleanous / Clone Git Project” action.
-This will open a field in which you should enter the following Git reposity address:
+This will open a field in which you should enter the following Git repository address:
 
 ```
 https://github.com/owntech-foundation/Core
@@ -130,7 +132,7 @@ as highlighted in the following screenshot:
 
 Now the project is successfully opened and you should see two tabs in the Editor area:
 
-- the “PIO Home” tab thay we will not use here
+- the “PIO Home” tab that we will not use here
   (remark: PIO Home’s Devices tab can be used to check that your board is well detected once connected)
 - the `platformio.ini` [Project Configuration File](https://docs.platformio.org/en/latest/projectconf/index.html),
   which is already well configured for the present example
@@ -170,7 +172,7 @@ Before running the code, make sure that you meet the following requirements:
      - Have a SPIN board ready (stand-alone or embedded on a TWIST)
 
 === " "
-    ![USB Connection of a SPIN board embeeded onto a TWIST board](images/example-fig1-usb_connection.svg){align=left}
+    ![USB Connection of a SPIN board embedded onto a TWIST board](images/example-fig1-usb_connection.svg){align=left}
 
     - Connect the SPIN board to your computer via the USB.
     - Notice that the LED PWR must turn on.
@@ -188,7 +190,7 @@ To do so, press the Upload icon (`→`, just to the right of the Build icon `✓
     The Build and Upload action buttons are also available in the top right corner of the Editor area
 
 !!! tip "Coffee time 2"
-    During your first upload, PlatformIO will automatically download the necessary depencies to send data to the SPIN board. Depending on your machine and your internet connection, this might take some time.
+    During your first upload, PlatformIO will automatically download the necessary dependencies to send data to the SPIN board. Depending on your machine and your internet connection, this might take some time.
 
     Time to pour another coffee.
 
@@ -220,7 +222,7 @@ After saving the modified code, you will need to redo the Build and Upload steps
 
 ## Troubleshooting
 
-From our exeprience, there are multiple types of errors that can block your compilation.
+From our experience, there are multiple types of errors that can block your compilation.
 
 Check the list below of possible issues
 
@@ -237,7 +239,7 @@ Check the list below of possible issues
         - You should preferably have your project folder as close as possible to the root
         - Be sure the SPIN board PWR LED lights up correctly when connected to the USB
         - Check your USB-C cable is working and can handle data
-        - Check your internet connectin is up and running
+        - Check your internet connection is up and running
 
     === "macOS"
         - **Git:** If you do not have git installed, get it here [git for macOS](https://git-scm.com/download/mac)
@@ -245,7 +247,7 @@ Check the list below of possible issues
         - **CMake:** If you do not have CMake installed, get it here [CMake Installer](https://cmake.org/download/)
         - Be sure the SPIN board PWR LED lights up correctly when connected to the USB
         - Check your USB-C cable is working and can handle data
-        - Check your internet connectin is up and running
+        - Check your internet connection is up and running
         - If you have a problem with `mcumgr`, please refer to the [ongoing issue](https://github.com/owntech-foundation/Core/issues/5) to handle it.
 
 
@@ -254,10 +256,10 @@ Check the list below of possible issues
          - **Git:** If you do not have git installed, get it here [git for Linux](https://git-scm.com/download/linux)
         - **Python3:** If you do not have python3 installed, get it here [Python3 Installers](https://docs.python-guide.org/starting/install3/linux/)
         - **CMake:** If you do not have CMake installed, get it here [CMake Installer](https://cmake.org/download/)
-        - Check that your Linux is 64bits
+        - Check that your Linux is 64 bits
         - Be sure the SPIN board PWR LED lights up correctly when connected to the USB
         - Check your USB-C cable is working and can handle data
-        - Check your internet connectin is up and running
+        - Check your internet connection is up and running
 
 
 


### PR DESCRIPTION
This is a follow-up of PR
https://github.com/owntech-foundation/Core/pull/78 where I had:
- left or introduced some typos, and more importantly
- broke the [mkdocs-material annotation](https://squidfunk.github.io/mkdocs-material/reference/annotations/) (for the VS Code Extensions and PlatformIO icons) in the [Environment Setup](https://docs.owntech.org/core/docs/environment_setup/) documentation.