### PR TITLE
Fixing snake case in SafetyAPI.

### DIFF
--- a/zephyr/modules/owntech_safety_api/zephyr/public_api/SafetyAPI.cpp
+++ b/zephyr/modules/owntech_safety_api/zephyr/public_api/SafetyAPI.cpp
@@ -30,12 +30,12 @@
 
 SafetyAPI safety;
 
-void SafetyAPI::init_shield()
+void SafetyAPI::initShield()
 {
     safety_init_shield(true);
 }
 
-void SafetyAPI::init_shield(sensor_t* sensors_watch, uint8_t sensors_watch_number)
+void SafetyAPI::initShield(sensor_t* sensors_watch, uint8_t sensors_watch_number)
 {
     safety_init_shield(false);
     safety_set_sensor_watch(sensors_watch, sensors_watch_number);

--- a/zephyr/modules/owntech_safety_api/zephyr/public_api/SafetyAPI.h
+++ b/zephyr/modules/owntech_safety_api/zephyr/public_api/SafetyAPI.h
@@ -45,7 +45,7 @@ class SafetyAPI{
      *
      * @return none
     */
-    void init_shield();
+    void initShield();
 
     /**
      * @brief Initializes thresholds min/max with the default value from the device tree,
@@ -58,7 +58,7 @@ class SafetyAPI{
      *
      * @return none
     */
-    void init_shield(sensor_t* sensors_watch, uint8_t sensors_watch_number);
+    void initShield(sensor_t* sensors_watch, uint8_t sensors_watch_number);
 
     /**
      * @brief Enables the monitoring of the selected sensors for safety.


### PR DESCRIPTION
After a discussion with @cfoucher-laas we explicited the following rules : 

There are 3 main categories of files in Core:
- Drivers
- HALs
- APIs

Drivers adopt naming convention including driver name followed by snake case 
HALs adopt snake case convention
APIs adopts lower camel case

I've been through all files of core and find this discrepancy, fixing it will finally close this long lasting issue. 

Closes #39 