### PR TITLE
Improve VSCode settings ignore script

### DIFF
--- a/owntech/pio_extra.ini
+++ b/owntech/pio_extra.ini
@@ -70,6 +70,7 @@ debug_init_cmds =
 debug_load_cmds =
 
 extra_scripts =
+    pre:owntech/scripts/pre_ignore_vscode.py
     pre:owntech/scripts/pre_target_gui_config.py
     pre:owntech/scripts/pre_target_install_bootloader.py
     pre:owntech/scripts/pre_bootloader_common.py
@@ -101,6 +102,7 @@ upload_flags =
 upload_command = MCUMGRPATH $UPLOAD_FLAGS $SOURCE
 
 extra_scripts =
+    pre:owntech/scripts/pre_ignore_vscode.py
     pre:owntech/scripts/pre_target_gui_config.py
     pre:owntech/scripts/pre_bootloader_common.py
     pre:owntech/scripts/pre_bootloader_serial.py

--- a/owntech/scripts/pre_ignore_vscode.py
+++ b/owntech/scripts/pre_ignore_vscode.py
@@ -1,0 +1,25 @@
+"""Mark VSCode settings as assume-unchanged with minimal overhead."""
+
+from pathlib import Path
+import subprocess
+
+
+def main() -> None:
+    settings = Path(".vscode") / "settings.json"
+    flag = Path(".pio") / "ignore_vscode.flag"
+
+    if not settings.is_file() or flag.exists():
+        return
+
+    subprocess.run(
+        ["git", "update-index", "--assume-unchanged", str(settings)], check=False
+    )
+
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.write_text("done")
+
+
+if __name__ == "__main__":
+    main()
+
+


### PR DESCRIPTION
## Summary
- update script to run the git command only once and exit quickly afterward

## Testing
- `python3 -m py_compile owntech/scripts/pre_ignore_vscode.py`


------
https://chatgpt.com/codex/tasks/task_b_685c0727313c83219990dc32558a190c