### PR TITLE
Update to Zephyr 4.1

### DIFF
--- a/owntech/pio_extra.ini
+++ b/owntech/pio_extra.ini
@@ -12,7 +12,7 @@ monitor_dir = owntech/scripts/monitor
 [env]
 
 # Platform and OS
-platform = ststm32@19.0.0
+platform = ststm32@19.2.0
 framework = zephyr
 
 platform_packages =

--- a/zephyr/boards/owntech/spin/spin.dts
+++ b/zephyr/boards/owntech/spin/spin.dts
@@ -238,7 +238,7 @@ zephyr_udc0: &usb {
 &adc1 {
 	pinctrl-0 = <&adc1_in6_pc0 &adc1_in7_pc1 &adc1_in8_pc2 &adc1_in9_pc3>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
@@ -246,7 +246,7 @@ zephyr_udc0: &usb {
 &adc2 {
 	pinctrl-0 = <&adc2_in1_pa0 &adc2_in2_pa1 &adc2_in3_pa6 &adc2_in5_pc4>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
@@ -254,7 +254,7 @@ zephyr_udc0: &usb {
 &adc3 {
 	pinctrl-0 = <&adc3_in1_pb1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
@@ -262,7 +262,7 @@ zephyr_udc0: &usb {
 &adc4 {
 	pinctrl-0 = <&adc4_in5_pb15>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
@@ -270,7 +270,7 @@ zephyr_udc0: &usb {
 &adc5 {
 	pinctrl-0 = <&adc5_in1_pa8 &adc5_in2_pa9>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };


### PR DESCRIPTION
Untested.
Only adapted the required fields in the device tree to make it compile.