### PR TITLE
[bug] Updates the power API to correct a frequency update related bug.

### DIFF
--- a/zephyr/modules/owntech_shield_api/zephyr/src/Power.cpp
+++ b/zephyr/modules/owntech_shield_api/zephyr/src/Power.cpp
@@ -623,6 +623,15 @@ void PowerAPI::setDeadTime(leg_t leg,
 void PowerAPI::setFrequency(uint32_t frequency)
 {
     spin.pwm.setFrequency(frequency);
+
+    /* spin.pwm.setFrequency() clamps below timer_min_frequency, so mirror
+     * that clamping here to keep timer_frequency consistent with the
+     * frequency actually applied to the PWM. */
+    if (frequency < timer_min_frequency)
+    {
+        frequency = timer_min_frequency;
+    }
+
     timer_frequency = frequency;
 
     for (int8_t i = 0; i < dt_leg_count; i++)

--- a/zephyr/modules/owntech_shield_api/zephyr/src/Power.cpp
+++ b/zephyr/modules/owntech_shield_api/zephyr/src/Power.cpp
@@ -205,13 +205,27 @@ void PowerAPI::initMode(leg_t leg,
 
 void PowerAPI::setDutyCycle(leg_t leg, float32_t duty_value)
 {
-    uint16_t period;
-    uint16_t value;
+    int8_t startIndex = 0;
+    int8_t endIndex = 0;
 
-    period = tu_channel[spinNumberToTu(dt_pwm_pin[leg])]->pwm_conf.period;
-    value = duty_value * period;
+    if (leg == ALL)
+    {
+        startIndex = 0;
+        endIndex = dt_leg_count;
+    }
+    else
+    {
+        startIndex = leg;
+        endIndex = leg + 1;
+    }
 
-    setDutyCycleRaw(leg, value);
+    for (int8_t i = startIndex; i < endIndex; i++)
+    {
+        hrtim_tu_number_t leg_tu = spinNumberToTu(dt_pwm_pin[i]);
+        uint16_t period = tu_channel[leg_tu]->pwm_conf.period;
+        uint16_t value = duty_value * period;
+        setDutyCycleRaw(static_cast<leg_t>(i), value);
+    }
 }
 
 void PowerAPI::setDutyCycleRaw(leg_t leg, uint16_t duty_value)
@@ -606,6 +620,33 @@ void PowerAPI::setDeadTime(leg_t leg,
     }
 }
 
+void PowerAPI::setFrequency(uint32_t frequency)
+{
+    spin.pwm.setFrequency(frequency);
+    timer_frequency = frequency;
+
+    for (int8_t i = 0; i < dt_leg_count; i++)
+    {
+        hrtim_tu_number_t leg_tu = spinNumberToTu(dt_pwm_pin[i]);
+        uint16_t period = tu_channel[leg_tu]->pwm_conf.period;
+
+        tu_channel[leg_tu]->pwm_conf.duty_min_user =
+            tu_channel[leg_tu]->pwm_conf.duty_min_user_float * period;
+        tu_channel[leg_tu]->pwm_conf.duty_max_user =
+            tu_channel[leg_tu]->pwm_conf.duty_max_user_float * period;
+    }
+}
+
+uint32_t PowerAPI::getFrequency()
+{
+    return timer_frequency;
+}
+
+uint32_t PowerAPI::getFrequencyMin()
+{
+    return timer_min_frequency;
+}
+
 
 void PowerAPI::setDutyCycleMin(leg_t leg, float32_t duty_cycle){
     int8_t startIndex = 0;
@@ -698,7 +739,8 @@ void PowerAPI::setDutyCycleMinRaw(leg_t leg, uint16_t duty_cycle){
         tu_channel[leg_tu]->pwm_conf.duty_min_user = duty_cycle;
         uint16_t period = tu_channel[leg_tu]->pwm_conf.period;
         tu_channel[leg_tu]->pwm_conf.duty_min_user_float = 
-                                            (float32_t)(duty_cycle/period);
+                                            (float32_t)duty_cycle /
+                                            (float32_t)period;
         
     }
 
@@ -734,7 +776,8 @@ void PowerAPI::setDutyCycleMaxRaw(leg_t leg,uint16_t duty_cycle){
         }    
         tu_channel[leg_tu]->pwm_conf.duty_max_user = duty_cycle;
         tu_channel[leg_tu]->pwm_conf.duty_max_user_float = 
-                                                (float32_t)(duty_cycle/period);
+                                                (float32_t)duty_cycle /
+                                                (float32_t)period;
     }
 }
 

--- a/zephyr/modules/owntech_shield_api/zephyr/src/Power.h
+++ b/zephyr/modules/owntech_shield_api/zephyr/src/Power.h
@@ -217,6 +217,30 @@ public:
 					 uint16_t ns_falling_dt);
 
 	/**
+	 * @brief Sets the PWM frequency shared by the shield legs.
+	 *
+	 * This updates the underlying HRTIM period and refreshes duty-cycle
+	 * limits so subsequent duty updates stay aligned with the new period.
+	 *
+	 * @param frequency switching frequency in Hz
+	 */
+	void setFrequency(uint32_t frequency);
+
+	/**
+	 * @brief Gets the currently configured shared PWM frequency in Hz.
+	 *
+	 * @return shared switching frequency in Hz
+	 */
+	uint32_t getFrequency();
+
+	/**
+	 * @brief Gets the minimum allowed shared PWM frequency in Hz.
+	 *
+	 * @return minimum switching frequency in Hz
+	 */
+	uint32_t getFrequencyMin();
+
+	/**
 	 * @brief sets the Minimum Duty Cycle Limit
 	 *
 	 * @param leg the leg for which to set dead time value: `LEG1` to `ALL`


### PR DESCRIPTION
## Context

When frequency is updated, the duty cycle is not. 

This means that when updating the duty cycle the period is not refreshed and the values passed to the spin API were wrong.

## Correction

I've created a setFrenquency, getFrequency and getFrenquecyMin so that the user can manipulate the frequency with better ease.

## Tests

I've built and tested it with the test code that will be attached on the next message. 