### PR TITLE
[SENSOR API] Improvement of the default sensor activation on the shield sensorAPI

### DIFF
--- a/zephyr/boards/shields/ownverter/ownverter_v0_9_0.overlay
+++ b/zephyr/boards/shields/ownverter/ownverter_v0_9_0.overlay
@@ -69,6 +69,8 @@
 		v1low: v1-low {
 			compatible = "shield-sensors";
 			sensor-name = "V1_LOW";
+			default-adc = "ADC_1";
+			default-order = <0>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -86,6 +88,8 @@
 		v2low: v2-low {
 			compatible = "shield-sensors";
 			sensor-name = "V2_LOW";
+			default-adc = "ADC_1";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -103,6 +107,8 @@
 		v3low: v3-low {
 			compatible = "shield-sensors";
 			sensor-name = "V3_LOW";
+			default-adc = "ADC_2";
+			default-order = <2>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -120,6 +126,8 @@
 		vhigh: v-high {
 			compatible = "shield-sensors";
 			sensor-name = "V_HIGH";
+			default-adc = "ADC_1";
+			default-order = <3>;
 			default-gain = <0x3cf57710>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -137,6 +145,8 @@
 		vneutr: vneutr {
 			compatible = "shield-sensors";
 			sensor-name = "V_NEUTR";
+			default-adc = "ADC_1";
+			default-order = <4>;
 			default-gain = <0x3f800000>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -152,6 +162,8 @@
 		i1low: i1-low {
 			compatible = "shield-sensors";
 			sensor-name = "I1_LOW";
+			default-adc = "ADC_2";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -169,6 +181,8 @@
 		i2low: i2-low {
 			compatible = "shield-sensors";
 			sensor-name = "I2_LOW";
+			default-adc = "ADC_2";
+			default-order = <1>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -186,6 +200,8 @@
 		i3low: i3-low {
 			compatible = "shield-sensors";
 			sensor-name = "I3_LOW";
+			default-adc = "ADC_1";
+			default-order = <2>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -203,6 +219,8 @@
 		ihigh: i-high {
 			compatible = "shield-sensors";
 			sensor-name = "I_HIGH";
+			default-adc = "ADC_2";
+			default-order = <3>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -222,6 +240,8 @@
 		temp: temp-sensor {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR";
+			default-adc = "ADC_2";
+			default-order = <4>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;

--- a/zephyr/boards/shields/ownverter/ownverter_v1_0_0.overlay
+++ b/zephyr/boards/shields/ownverter/ownverter_v1_0_0.overlay
@@ -70,6 +70,8 @@
 		v1low: v1-low {
 			compatible = "shield-sensors";
 			sensor-name = "V1_LOW";
+			default-adc = "ADC_1";
+			default-order = <0>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -87,6 +89,8 @@
 		v2low: v2-low {
 			compatible = "shield-sensors";
 			sensor-name = "V2_LOW";
+			default-adc = "ADC_1";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -104,6 +108,8 @@
 		v3low: v3-low {
 			compatible = "shield-sensors";
 			sensor-name = "V3_LOW";
+			default-adc = "ADC_2";
+			default-order = <2>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -117,6 +123,8 @@
 		vhigh: v-high {
 			compatible = "shield-sensors";
 			sensor-name = "V_HIGH";
+			default-adc = "ADC_1";
+			default-order = <3>;
 			default-gain = <0x3cf57710>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -134,6 +142,8 @@
 		vneutr: vneutr {
 			compatible = "shield-sensors";
 			sensor-name = "V_NEUTR";
+			default-adc = "ADC_1";
+			default-order = <4>;
 			default-gain = <0x3f800000>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -149,6 +159,8 @@
 		i1low: i1-low {
 			compatible = "shield-sensors";
 			sensor-name = "I1_LOW";
+			default-adc = "ADC_2";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -166,6 +178,8 @@
 		i2low: i2-low {
 			compatible = "shield-sensors";
 			sensor-name = "I2_LOW";
+			default-adc = "ADC_2";
+			default-order = <1>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -183,6 +197,8 @@
 		i3low: i3-low {
 			compatible = "shield-sensors";
 			sensor-name = "I3_LOW";
+			default-adc = "ADC_1";
+			default-order = <2>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -200,6 +216,8 @@
 		ihigh: i-high {
 			compatible = "shield-sensors";
 			sensor-name = "I_HIGH";
+			default-adc = "ADC_2";
+			default-order = <3>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -219,6 +237,8 @@
 		temp: temp-sensor {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR";
+			default-adc = "ADC_2";
+			default-order = <4>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;

--- a/zephyr/boards/shields/ownverter/ownverter_v1_1_0.overlay
+++ b/zephyr/boards/shields/ownverter/ownverter_v1_1_0.overlay
@@ -70,6 +70,8 @@
 		v1low: v1-low {
 			compatible = "shield-sensors";
 			sensor-name = "V1_LOW";
+			default-adc = "ADC_1";
+			default-order = <0>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -87,6 +89,8 @@
 		v2low: v2-low {
 			compatible = "shield-sensors";
 			sensor-name = "V2_LOW";
+			default-adc = "ADC_1";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -104,6 +108,8 @@
 		v3low: v3-low {
 			compatible = "shield-sensors";
 			sensor-name = "V3_LOW";
+			default-adc = "ADC_2";
+			default-order = <2>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -117,6 +123,8 @@
 		vhigh: v-high {
 			compatible = "shield-sensors";
 			sensor-name = "V_HIGH";
+			default-adc = "ADC_1";
+			default-order = <3>;
 			default-gain = <0x3cf57710>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -134,6 +142,8 @@
 		vneutr: vneutr {
 			compatible = "shield-sensors";
 			sensor-name = "V_NEUTR";
+			default-adc = "ADC_1";
+			default-order = <4>;
 			default-gain = <0x3f800000>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -149,6 +159,8 @@
 		i1low: i1-low {
 			compatible = "shield-sensors";
 			sensor-name = "I1_LOW";
+			default-adc = "ADC_2";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -166,6 +178,8 @@
 		i2low: i2-low {
 			compatible = "shield-sensors";
 			sensor-name = "I2_LOW";
+			default-adc = "ADC_2";
+			default-order = <1>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -183,6 +197,8 @@
 		i3low: i3-low {
 			compatible = "shield-sensors";
 			sensor-name = "I3_LOW";
+			default-adc = "ADC_1";
+			default-order = <2>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -200,6 +216,8 @@
 		ihigh: i-high {
 			compatible = "shield-sensors";
 			sensor-name = "I_HIGH";
+			default-adc = "ADC_2";
+			default-order = <3>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -219,6 +237,8 @@
 		temp: temp-sensor {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR";
+			default-adc = "ADC_2";
+			default-order = <4>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;

--- a/zephyr/boards/shields/twist/sensors.dtsi
+++ b/zephyr/boards/shields/twist/sensors.dtsi
@@ -12,6 +12,8 @@
 		v1low: v1-low {
 			compatible = "shield-sensors";
 			sensor-name = "V1_LOW";
+			default-adc = "ADC_1";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			v1-low-adc1 {
@@ -27,6 +29,8 @@
 		v2low: v2-low {
 			compatible = "shield-sensors";
 			sensor-name = "V2_LOW";
+			default-adc = "ADC_2";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			v2-low-adc1 {
@@ -42,6 +46,8 @@
 		vhigh: v-high {
 			compatible = "shield-sensors";
 			sensor-name = "V_HIGH";
+			default-adc = "ADC_1";
+			default-order = <2>;
 			default-gain = <0x3cf57710>;
 			default-offset = <0x00000000>;
 			v-high-adc1 {
@@ -59,6 +65,8 @@
 		i1low: i1-low {
 			compatible = "shield-sensors";
 			sensor-name = "I1_LOW";
+			default-adc = "ADC_1";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			i1-low-adc1 {
@@ -74,6 +82,8 @@
 		i2low: i2-low {
 			compatible = "shield-sensors";
 			sensor-name = "I2_LOW";
+			default-adc = "ADC_2";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			i2-low-adc1 {
@@ -89,6 +99,8 @@
 		ihigh: i-high {
 			compatible = "shield-sensors";
 			sensor-name = "I_HIGH";
+			default-adc = "ADC_2";
+			default-order = <2>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			i-high-adc1 {

--- a/zephyr/boards/shields/twist/twist_v1_2_0.overlay
+++ b/zephyr/boards/shields/twist/twist_v1_2_0.overlay
@@ -56,6 +56,8 @@
 		v1low: v1-low {
 			compatible = "shield-sensors";
 			sensor-name = "V1_LOW";
+			default-adc = "ADC_1";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -73,6 +75,8 @@
 		v2low: v2-low {
 			compatible = "shield-sensors";
 			sensor-name = "V2_LOW";
+			default-adc = "ADC_2";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -90,6 +94,8 @@
 		vhigh: v-high {
 			compatible = "shield-sensors";
 			sensor-name = "V_HIGH";
+			default-adc = "ADC_1";
+			default-order = <2>;
 			default-gain = <0x3cf57710>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -109,6 +115,8 @@
 		i1low: i1-low {
 			compatible = "shield-sensors";
 			sensor-name = "I1_LOW";
+			default-adc = "ADC_1";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -126,6 +134,8 @@
 		i2low: i2-low {
 			compatible = "shield-sensors";
 			sensor-name = "I2_LOW";
+			default-adc = "ADC_2";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -143,6 +153,8 @@
 		ihigh: i-high {
 			compatible = "shield-sensors";
 			sensor-name = "I_HIGH";
+			default-adc = "ADC_2";
+			default-order = <2>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -162,6 +174,8 @@
 		temp1: temp-sensor-1 {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR_1";
+			default-adc = "ADC_4";
+			default-order = <0>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;
@@ -177,6 +191,8 @@
 		temp2: temp-sensor-2 {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR_2";
+			default-adc = "ADC_3";
+			default-order = <0>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;

--- a/zephyr/boards/shields/twist/twist_v1_3_0.overlay
+++ b/zephyr/boards/shields/twist/twist_v1_3_0.overlay
@@ -55,6 +55,8 @@
 		v1low: v1-low {
 			compatible = "shield-sensors";
 			sensor-name = "V1_LOW";
+			default-adc = "ADC_1";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -72,6 +74,8 @@
 		v2low: v2-low {
 			compatible = "shield-sensors";
 			sensor-name = "V2_LOW";
+			default-adc = "ADC_2";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -89,6 +93,8 @@
 		vhigh: v-high {
 			compatible = "shield-sensors";
 			sensor-name = "V_HIGH";
+			default-adc = "ADC_1";
+			default-order = <2>;
 			default-gain = <0x3cf57710>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -108,6 +114,8 @@
 		i1low: i1-low {
 			compatible = "shield-sensors";
 			sensor-name = "I1_LOW";
+			default-adc = "ADC_1";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -125,6 +133,8 @@
 		i2low: i2-low {
 			compatible = "shield-sensors";
 			sensor-name = "I2_LOW";
+			default-adc = "ADC_2";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -142,6 +152,8 @@
 		ihigh: i-high {
 			compatible = "shield-sensors";
 			sensor-name = "I_HIGH";
+			default-adc = "ADC_2";
+			default-order = <2>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -161,6 +173,8 @@
 		temp1: temp-sensor-1 {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR_1";
+			default-adc = "ADC_4";
+			default-order = <0>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;
@@ -176,6 +190,8 @@
 		temp2: temp-sensor-2 {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR_2";
+			default-adc = "ADC_3";
+			default-order = <0>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;

--- a/zephyr/boards/shields/twist/twist_v1_4_0.overlay
+++ b/zephyr/boards/shields/twist/twist_v1_4_0.overlay
@@ -57,6 +57,8 @@
 		v1low: v1-low {
 			compatible = "shield-sensors";
 			sensor-name = "V1_LOW";
+			default-adc = "ADC_1";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -74,6 +76,8 @@
 		v2low: v2-low {
 			compatible = "shield-sensors";
 			sensor-name = "V2_LOW";
+			default-adc = "ADC_2";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -91,6 +95,8 @@
 		vhigh: v-high {
 			compatible = "shield-sensors";
 			sensor-name = "V_HIGH";
+			default-adc = "ADC_1";
+			default-order = <2>;
 			default-gain = <0x3cf57710>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -110,6 +116,8 @@
 		i1low: i1-low {
 			compatible = "shield-sensors";
 			sensor-name = "I1_LOW";
+			default-adc = "ADC_1";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			spin-pin = <30>;
@@ -128,6 +136,8 @@
 		i2low: i2-low {
 			compatible = "shield-sensors";
 			sensor-name = "I2_LOW";
+			default-adc = "ADC_2";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -145,6 +155,8 @@
 		ihigh: i-high {
 			compatible = "shield-sensors";
 			sensor-name = "I_HIGH";
+			default-adc = "ADC_2";
+			default-order = <2>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -164,6 +176,8 @@
 		temp1: temp-sensor-1 {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR_1";
+			default-adc = "ADC_4";
+			default-order = <0>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;
@@ -179,6 +193,8 @@
 		temp2: temp-sensor-2 {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR_2";
+			default-adc = "ADC_3";
+			default-order = <0>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;

--- a/zephyr/boards/shields/twist/twist_v1_4_1.overlay
+++ b/zephyr/boards/shields/twist/twist_v1_4_1.overlay
@@ -58,6 +58,8 @@
 		v1low: v1-low {
 			compatible = "shield-sensors";
 			sensor-name = "V1_LOW";
+			default-adc = "ADC_1";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -75,6 +77,8 @@
 		v2low: v2-low {
 			compatible = "shield-sensors";
 			sensor-name = "V2_LOW";
+			default-adc = "ADC_2";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -92,6 +96,8 @@
 		vhigh: v-high {
 			compatible = "shield-sensors";
 			sensor-name = "V_HIGH";
+			default-adc = "ADC_1";
+			default-order = <2>;
 			default-gain = <0x3cf57710>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -111,6 +117,8 @@
 		i1low: i1-low {
 			compatible = "shield-sensors";
 			sensor-name = "I1_LOW";
+			default-adc = "ADC_1";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -128,6 +136,8 @@
 		i2low: i2-low {
 			compatible = "shield-sensors";
 			sensor-name = "I2_LOW";
+			default-adc = "ADC_2";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -145,6 +155,8 @@
 		ihigh: i-high {
 			compatible = "shield-sensors";
 			sensor-name = "I_HIGH";
+			default-adc = "ADC_2";
+			default-order = <2>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -164,6 +176,8 @@
 		temp1: temp-sensor-1 {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR_1";
+			default-adc = "ADC_4";
+			default-order = <0>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;
@@ -179,6 +193,8 @@
 		temp2: temp-sensor-2 {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR_2";
+			default-adc = "ADC_3";
+			default-order = <0>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;

--- a/zephyr/boards/shields/twist/twist_v1_4_2.overlay
+++ b/zephyr/boards/shields/twist/twist_v1_4_2.overlay
@@ -58,6 +58,8 @@
 		v1low: v1-low {
 			compatible = "shield-sensors";
 			sensor-name = "V1_LOW";
+			default-adc = "ADC_1";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -75,6 +77,8 @@
 		v2low: v2-low {
 			compatible = "shield-sensors";
 			sensor-name = "V2_LOW";
+			default-adc = "ADC_2";
+			default-order = <1>;
 			default-gain = <0x3d3851ec>;
 			default-offset = <0xc2b867f0>;
 			sensor-conv-type = "LINEAR";
@@ -92,6 +96,8 @@
 		vhigh: v-high {
 			compatible = "shield-sensors";
 			sensor-name = "V_HIGH";
+			default-adc = "ADC_1";
+			default-order = <2>;
 			default-gain = <0x3cf57710>;
 			default-offset = <0x00000000>;
 			sensor-conv-type = "LINEAR";
@@ -111,6 +117,8 @@
 		i1low: i1-low {
 			compatible = "shield-sensors";
 			sensor-name = "I1_LOW";
+			default-adc = "ADC_1";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -128,6 +136,8 @@
 		i2low: i2-low {
 			compatible = "shield-sensors";
 			sensor-name = "I2_LOW";
+			default-adc = "ADC_2";
+			default-order = <0>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -145,6 +155,8 @@
 		ihigh: i-high {
 			compatible = "shield-sensors";
 			sensor-name = "I_HIGH";
+			default-adc = "ADC_2";
+			default-order = <2>;
 			default-gain = <0x3ba3d70a>;
 			default-offset = <0xc1200000>;
 			sensor-conv-type = "LINEAR";
@@ -164,6 +176,8 @@
 		temp1: temp-sensor-1 {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR_1";
+			default-adc = "ADC_4";
+			default-order = <0>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;
@@ -179,6 +193,8 @@
 		temp2: temp-sensor-2 {
 			compatible = "shield-sensors";
 			sensor-name = "TEMP_SENSOR_2";
+			default-adc = "ADC_3";
+			default-order = <0>;
 			default-r0 = <0x461c4000>;
 			default-b = <0x4557a000>;
 			default-rdiv = <0x469c4000>;

--- a/zephyr/dts/bindings/shield-sensors.yaml
+++ b/zephyr/dts/bindings/shield-sensors.yaml
@@ -54,10 +54,33 @@ properties:
     description: PIN IN 1 used in the mux for temperature sensor on the Ownverter. 
 
 
+  default-adc:
+    type: string
+    required: false
+    default: "UNKNOWN_ADC"
+    enum:
+      - "UNKNOWN_ADC"
+      - "ADC_1"
+      - "ADC_2"
+      - "ADC_3"
+      - "ADC_4"
+      - "ADC_5"
+    description: Default ADC used for acquisition by enableDefaultSensors().
+                 UNKNOWN_ADC means the sensor is not enabled by default.
+
+  default-order:
+    type: int
+    required: false
+    default: 255
+    description: Position in the enableDefaultSensors() acquisition sequence.
+                 Lower values are enabled first, determining the per-ADC channel
+                 order. Only meaningful when default-adc is not UNKNOWN_ADC.
+                 Sensors without this property (default 255) are not ordered.
+
   sensor-conv-type:
     type: string
     required: false
-    description: Type of conversion performed by the sensor. Typically LINEAR or LOG. 
+    description: Type of conversion performed by the sensor. Typically LINEAR or LOG.
 
 
 child-binding:

--- a/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.cpp
+++ b/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.cpp
@@ -370,10 +370,19 @@ void SensorsAPI::setOwnverterTempMeas(ownverter_temp_sensor_t temperature_sensor
 	}
 }
 
+void SensorsAPI::enableDefaultOwnverterSensors()
+{
+	this->enableDefaultSensors();
+}
 
 #endif
 
 #ifdef CONFIG_SHIELD_TWIST
+
+void SensorsAPI::enableDefaultTwistSensors()
+{
+	this->enableDefaultSensors();
+}
 
 void SensorsAPI::triggerTwistTempMeas(sensor_t temperature_sensor)
 {

--- a/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.cpp
+++ b/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.cpp
@@ -102,6 +102,23 @@
 #endif
 
 
+#define SENSOR_DEFAULT_ADC(node_id)   DT_STRING_TOKEN(node_id, default_adc),
+#define SENSOR_DEFAULT_ORDER(node_id) DT_PROP(node_id, default_order),
+
+/* Compile-time arrays used by enableDefaultSensors(). */
+static const sensor_t dt_default_sensor_names[] = {
+	DT_FOREACH_STATUS_OKAY(shield_sensors, SENSOR_TOKEN)
+};
+
+static const adc_t dt_default_adcs[] = {
+	DT_FOREACH_STATUS_OKAY(shield_sensors, SENSOR_DEFAULT_ADC)
+};
+
+static const uint8_t dt_default_orders[] = {
+	DT_FOREACH_STATUS_OKAY(shield_sensors, SENSOR_DEFAULT_ORDER)
+};
+
+
 /**
  *  Variables
  */
@@ -305,52 +322,39 @@ int8_t SensorsAPI::storeParametersInMemory(sensor_t sensor_name)
 			);
 }
 
-#ifdef CONFIG_SHIELD_OWNVERTER
-
-void SensorsAPI::enableDefaultOwnverterSensors()
+void SensorsAPI::enableDefaultSensors()
 {
-	/**
-	 * Defines the triggers of all ADCs.
-	 * 	ADC 1 - Triggered by HRTIM C, which is linked to event 3
-	 * 	ADC 2 - Triggered by HRTIM A, which is linked to event 1
-	 * 	ADC 3, 4 and 5 - Triggered by software
-	 * 					They are mainly used for non-real-time measurements,
-	 * 					such as temperature
-	 */
 	spin.data.configureTriggerSource(ADC_1, TRIG_PWM);
 	spin.data.configureTriggerSource(ADC_2, TRIG_PWM);
 	spin.data.configureTriggerSource(ADC_3, TRIG_SOFTWARE);
 	spin.data.configureTriggerSource(ADC_4, TRIG_SOFTWARE);
 	spin.data.configureTriggerSource(ADC_5, TRIG_SOFTWARE);
 
-	/**
-	 * Defines ADC 1 and ADC 2 measurements as discontinuous.
-	 * This is specially helpful for creating synchronous measurements.
-	 * Each measurement is done once per period of HRTIM at a precise moment
-	 */
 	spin.data.configureDiscontinuousMode(ADC_1, 1);
 	spin.data.configureDiscontinuousMode(ADC_2, 1);
 
-	/* Creates the list of measurements of the ADC 1 */
-	this->enableSensor(V1_LOW, ADC_1);
-	this->enableSensor(V2_LOW, ADC_1);
-	this->enableSensor(I3_LOW, ADC_1);
-	this->enableSensor(V_HIGH, ADC_1);
-	this->enableSensor(V_NEUTR, ADC_1);
+	/* Enable sensors per ADC in slot order. ADC_1 and ADC_2 fire
+	 * simultaneously, so sensors sharing the same default-order value
+	 * on different ADCs are acquired at the same trigger instant. */
+	uint8_t n = DT_PARENT_SENSORS_COUNT;
+	for (adc_t adc = ADC_1; adc <= ADC_5; adc = (adc_t)(adc + 1)) {
+		for (uint8_t slot = 0; slot < n; slot++) {
+			for (uint8_t i = 0; i < n; i++) {
+				if (dt_default_adcs[i] == adc && dt_default_orders[i] == slot) {
+					this->enableSensor(dt_default_sensor_names[i], adc);
+					break;
+				}
+			}
+		}
+	}
 
-	/* Creates the list of measurements of the ADC 2 */
-	this->enableSensor(I1_LOW, ADC_2);
-	this->enableSensor(I2_LOW, ADC_2);
-	this->enableSensor(V3_LOW, ADC_2);
-	this->enableSensor(I_HIGH, ADC_2);
-	this->enableSensor(TEMP_SENSOR, ADC_2);
-
-	/* Configure the pins of the temperature MUX */
-	spin.gpio.configurePin(temp_mux_in_1,OUTPUT);
-	spin.gpio.configurePin(temp_mux_in_2,OUTPUT);
-
-
+#ifdef CONFIG_SHIELD_OWNVERTER
+	spin.gpio.configurePin(temp_mux_in_1, OUTPUT);
+	spin.gpio.configurePin(temp_mux_in_2, OUTPUT);
+#endif
 }
+
+#ifdef CONFIG_SHIELD_OWNVERTER
 
 void SensorsAPI::setOwnverterTempMeas(ownverter_temp_sensor_t temperature_sensor)
 {
@@ -370,49 +374,6 @@ void SensorsAPI::setOwnverterTempMeas(ownverter_temp_sensor_t temperature_sensor
 #endif
 
 #ifdef CONFIG_SHIELD_TWIST
-
-void SensorsAPI::enableDefaultTwistSensors()
-{
-	/**
-	 * Defines the triggers of all ADCs.
-	 *  ADC 1 - Triggered by HRTIM C, which is linked to event 3
-	 *  ADC 2 - Triggered by HRTIM A, which is linked to event 1
-	 *  ADC 3, 4 and 5 - Triggered by software
-	 * 					They are mainly used for non-real-time measurements,
-	 * 					such as temperature
-	 */
-	spin.data.configureTriggerSource(ADC_1, TRIG_PWM);
-	spin.data.configureTriggerSource(ADC_2, TRIG_PWM);
-	spin.data.configureTriggerSource(ADC_3, TRIG_SOFTWARE);
-	spin.data.configureTriggerSource(ADC_4, TRIG_SOFTWARE);
-	spin.data.configureTriggerSource(ADC_5, TRIG_SOFTWARE);
-
-	/**
-	 * Defines ADC 1 and ADC 2 measurements as discontinuous.
-	 * This is specially helpful for creating synchronous measurements.
-	 * Each measurement is done once per period of HRTIM at a precise moment
-	 */
-	uint32_t num_discontinuous_meas = 1;
-	spin.data.configureDiscontinuousMode(ADC_1, num_discontinuous_meas);
-	spin.data.configureDiscontinuousMode(ADC_2, num_discontinuous_meas);
-
-	/* Creates the list of measurements of the ADC 1 */
-	this->enableSensor(I1_LOW, ADC_1);
-	this->enableSensor(V1_LOW, ADC_1);
-	this->enableSensor(V_HIGH, ADC_1);
-
-	/* Creates the list of measurements of the ADC 2 */
-	this->enableSensor(I2_LOW, ADC_2);
-	this->enableSensor(V2_LOW, ADC_2);
-	this->enableSensor(I_HIGH, ADC_2);
-
-	/* Creates the list of measurements of the ADC 3 */
-	int8_t test = this->enableSensor(TEMP_SENSOR_1, ADC_4);
-
-	/* Creates the list of measurements of the ADC 4 */
-	test = this->enableSensor(TEMP_SENSOR_2, ADC_3);
-
-}
 
 void SensorsAPI::triggerTwistTempMeas(sensor_t temperature_sensor)
 {

--- a/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.cpp
+++ b/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.cpp
@@ -88,7 +88,7 @@
 #define SUBSENSORS_COUNTER(node_id) \
 					DT_FOREACH_CHILD(node_id, SENSORS_COUNTER)
 
-#define DT_SENSORS_COUNT \
+#define DT_SUBSENSORS_COUNT \
 					DT_FOREACH_STATUS_OKAY(shield_sensors, SUBSENSORS_COUNTER)
 
 
@@ -149,7 +149,7 @@ SensorsAPI::sensor_dt_data_t** SensorsAPI::available_sensors_props[ADC_COUNT] = 
  * enabled, and a valid pointer will point to the structure
  * containing relevant information for this sensor.
  */
-SensorsAPI::sensor_dt_data_t* SensorsAPI::enabled_sensors[DT_SENSORS_COUNT] = {0};
+SensorsAPI::sensor_dt_data_t* SensorsAPI::enabled_sensors[DT_SUBSENSORS_COUNT] = {0};
 
 bool SensorsAPI::initialized = false;
 
@@ -336,7 +336,7 @@ void SensorsAPI::enableDefaultSensors()
 	/* Enable sensors per ADC in slot order. ADC_1 and ADC_2 fire
 	 * simultaneously, so sensors sharing the same default-order value
 	 * on different ADCs are acquired at the same trigger instant. */
-	uint8_t n = DT_PARENT_SENSORS_COUNT;
+	uint8_t n = DT_SENSORS_COUNT;
 	for (adc_t adc = ADC_1; adc <= ADC_5; adc = (adc_t)(adc + 1)) {
 		for (uint8_t slot = 0; slot < n; slot++) {
 			for (uint8_t i = 0; i < n; i++) {
@@ -617,7 +617,7 @@ void SensorsAPI::buildSensorListFromDeviceTree()
 
 	/* Retrieve calibration coefficients for each sensor listed in device tree */
 	for (uint8_t dt_sensor_index = 0 ;
-		 dt_sensor_index < DT_SENSORS_COUNT ;
+		 dt_sensor_index < DT_SUBSENSORS_COUNT ;
 		 dt_sensor_index++)
 	{
 		/* Determine ADC number based on its address */
@@ -814,7 +814,7 @@ void SensorsAPI::buildSensorListFromDeviceTree()
 	/* Populate the channels list for each ADC */
 	uint8_t adc_channels_count[ADC_COUNT] = {0};
 	for (uint8_t dt_sensor_index = 0 ;
-		 dt_sensor_index < DT_SENSORS_COUNT ;
+		 dt_sensor_index < DT_SUBSENSORS_COUNT ;
 		 dt_sensor_index++)
 	{
 		uint8_t adc_index = dt_sensors_props[dt_sensor_index].adc_number - 1;

--- a/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.h
+++ b/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.h
@@ -46,9 +46,12 @@
 /* Other modules public API */
 #include "SpinAPI.h"
 
-/* Device-tree related macro */
+/* Device-tree related macros */
 
-#define SENSOR_TOKEN(node_id) DT_STRING_TOKEN(node_id, sensor_name),
+#define SENSOR_TOKEN(node_id)      DT_STRING_TOKEN(node_id, sensor_name),
+#define SENSOR_PARENT_COUNT(node_id) +1
+#define DT_PARENT_SENSORS_COUNT \
+	(0 DT_FOREACH_STATUS_OKAY(shield_sensors, SENSOR_PARENT_COUNT))
 
 
 /* Type definitions */
@@ -409,32 +412,6 @@ public:
 #ifdef CONFIG_SHIELD_OWNVERTER
 
 	/**
-	 * @brief This function is used to enable acquisition of all voltage/current
-	 *        sensors on the OwnVerter shield.
-	 * 
-	 * @note  ADCs are triggered simultaneously.
-	 * 
-	 * @note  Sensors are attributed to ADC1 and ADC2 as follows: 
-	 * 
-	 * - `ADC1_LIST[5]`: [`V1_LOW`,`V2_LOW`, `I3_LOW`, `V_HIGH`, `V_NEUTR`    ]  
-	 *      
-	 * - `ADC2_LIST[5]`: [`I1_LOW`,`I2_LOW`, `V3_LOW`, `I_HIGH`, `TEMP_SENSOR`]
-	 *        
-	 * This function will configure ADC 1 and 2 to be automatically triggered 
-	 * by the HRTIM, so the board must be configured as a power converted to 
-	 * enable HRTIM events.
-	 * 
-	 * All other ADCs remain software triggered, thus will only be acquired 
-	 * when triggerAcquisition() is called.
-	 * 
-	 * It also configures the gpios that control the MUX that chooses which
-	 * temperature will be measured.
-	 *
-	 * @note  This function must be called *before* ADC is started.
-	 */
-	void enableDefaultOwnverterSensors();
-
-	/**
 	 * @brief This function sets the GPIOs attached to the MUX to control which
 	 * 		  temperature sensor will be measured.
 	 * 
@@ -459,31 +436,18 @@ public:
 	void setOwnverterTempMeas(ownverter_temp_sensor_t temperature_sensor);
 #endif
 
-#ifdef CONFIG_SHIELD_TWIST
-
 	/**
-	 * @brief This function is used to enable acquisition of all voltage/current
-	 *        sensors on the Twist shield.
-	 * 
-	 * @note  ADCs are triggered simultaneously.
-	 * 
-	 * @note  Sensors are attributed to ADC1 and ADC2 as follows: 
-	 * 
-	 * - `ADC1_LIST[3]`: [`V1_LOW`,`V2_LOW`,`V_HIGH`]  
-	 *      
-	 * - `ADC2_LIST[3]`: [`I1_LOW`,`I2_LOW`,`I_HIGH`]
+	 * @brief Enables acquisition for all sensors that have a `default-adc`
+	 *        property set in the device tree (i.e. not `UNKNOWN_ADC`).
 	 *
-	 * 	This function will configure ADC 1 and 2 to be automatically
-	 *  triggered by the HRTIM, so the board must be configured as
-	 *  a power converted to enable HRTIM events.
-	 * 
-	 *  All other ADCs remain software triggered, thus will only be
-	 *  acquired when triggerAcquisition() is called.
-	 * 
+	 * ADC1 and ADC2 are configured as PWM-triggered (synchronous with HRTIM).
+	 * ADC3-5 are software-triggered.
 	 *
-	 * @warning  This function must be called `before` ADC is started.
+	 * @note  This function must be called `before` ADC is started.
 	 */
-	void enableDefaultTwistSensors();
+	void enableDefaultSensors();
+
+#ifdef CONFIG_SHIELD_TWIST
 
 	/**
 	 * @brief Manually set parameters values using console. You will be directed

--- a/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.h
+++ b/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.h
@@ -49,9 +49,9 @@
 /* Device-tree related macros */
 
 #define SENSOR_TOKEN(node_id)      DT_STRING_TOKEN(node_id, sensor_name),
-#define SENSOR_PARENT_COUNT(node_id) +1
+#define SENSOR_COUNT(node_id) +1
 #define DT_PARENT_SENSORS_COUNT \
-	(0 DT_FOREACH_STATUS_OKAY(shield_sensors, SENSOR_PARENT_COUNT))
+	(0 DT_FOREACH_STATUS_OKAY(shield_sensors, SENSOR_COUNT))
 
 
 /* Type definitions */

--- a/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.h
+++ b/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.h
@@ -50,7 +50,7 @@
 
 #define SENSOR_TOKEN(node_id)      DT_STRING_TOKEN(node_id, sensor_name),
 #define SENSOR_COUNT(node_id) +1
-#define DT_PARENT_SENSORS_COUNT \
+#define DT_SENSORS_COUNT \
 	(0 DT_FOREACH_STATUS_OKAY(shield_sensors, SENSOR_COUNT))
 
 

--- a/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.h
+++ b/zephyr/modules/owntech_shield_api/zephyr/src/Sensors.h
@@ -434,6 +434,14 @@ public:
 	 * 
 	 */
 	void setOwnverterTempMeas(ownverter_temp_sensor_t temperature_sensor);
+
+	/**
+	 * @brief Deprecated. Use enableDefaultSensors() instead.
+	 *
+	 * @deprecated Kept for backward compatibility with existing user code;
+	 *             simply forwards to enableDefaultSensors().
+	 */
+	void enableDefaultOwnverterSensors();
 #endif
 
 	/**
@@ -448,6 +456,14 @@ public:
 	void enableDefaultSensors();
 
 #ifdef CONFIG_SHIELD_TWIST
+
+	/**
+	 * @brief Deprecated. Use enableDefaultSensors() instead.
+	 *
+	 * @deprecated Kept for backward compatibility with existing user code;
+	 *             simply forwards to enableDefaultSensors().
+	 */
+	void enableDefaultTwistSensors();
 
 	/**
 	 * @brief Manually set parameters values using console. You will be directed


### PR DESCRIPTION
# Context

The sensor API is used to adapt the spin data API to the specific sensors embedded onto a certain shield. 
To activate the default measurements of the shield, however, it was necessary to call a function that had the name of the shield onto it: 

```cpp
shield.sensors.enableDefaultTwistSensors();
shield.sensors.enableDefaultOwnverterSensors();
```

This approach had a serious of problem:  as each ADC has a list of variables to be measured. When we needed to change this list, either via the order or the number of variables in each adc, it required handling the low level code. 

# PR explanation

## Overlay modification

This PR adds a property to the measurements described in the overlay of the boards giving it a default ADC and a default measurement order on the adc list: 

```devicetree
		/* Voltage channels */
		v1low: v1-low {
			compatible = "shield-sensors";
/*--------------------- New parameters---------------------------- */
			sensor-name = "V1_LOW";
			default-adc = "ADC_1";
/*----------------------------------------------------------------------*/
			default-order = <0>;
			default-gain = <0x3d3851ec>;
			default-offset = <0xc2b867f0>;
			sensor-conv-type = "LINEAR";
			v1-low-adc1 {
				io-channels = <&adc1 6>;
				spin-pin = <24>;
			};
			v1-low-adc2 {
				io-channels = <&adc2 6>;
				spin-pin = <24>;
			};
			status = "okay";
		};
```

This opens the possibility of updating the default parameters via a dedicated `app.overlay`: 

```
&v1low {
 	default-adc = "ADC_2";
 	default-order = <0>;
 };
```

Thus, it becomes possible to change the order of the default measurements without modifying the low-level code. 

## Sensor API modification

With the addition of new properties, the sensor API now parses the information directly from the overlay, making it unecessary to have dedicated functions. Instead a single generic function can be called: 


```cpp
shield.sensors.enableDefaultSensors();
```

This generic function now simply activates the ADCs as is per-default in OwnTech's boards: 

```cpp
void SensorsAPI::enableDefaultSensors()
{
	spin.data.configureTriggerSource(ADC_1, TRIG_PWM);
	spin.data.configureTriggerSource(ADC_2, TRIG_PWM);
	spin.data.configureTriggerSource(ADC_3, TRIG_SOFTWARE);
	spin.data.configureTriggerSource(ADC_4, TRIG_SOFTWARE);
	spin.data.configureTriggerSource(ADC_5, TRIG_SOFTWARE);

	spin.data.configureDiscontinuousMode(ADC_1, 1);
	spin.data.configureDiscontinuousMode(ADC_2, 1);

	/* Enable sensors per ADC in slot order. ADC_1 and ADC_2 fire
	 * simultaneously, so sensors sharing the same default-order value
	 * on different ADCs are acquired at the same trigger instant. */
	uint8_t n = DT_PARENT_SENSORS_COUNT;
	for (adc_t adc = ADC_1; adc <= ADC_5; adc = (adc_t)(adc + 1)) {
		for (uint8_t slot = 0; slot < n; slot++) {
			for (uint8_t i = 0; i < n; i++) {
				if (dt_default_adcs[i] == adc && dt_default_orders[i] == slot) {
					this->enableSensor(dt_default_sensor_names[i], adc);
					break;
				}
			}
		}
	}

#ifdef CONFIG_SHIELD_OWNVERTER
	spin.gpio.configurePin(temp_mux_in_1, OUTPUT);
	spin.gpio.configurePin(temp_mux_in_2, OUTPUT);
#endif
}
```

Notice that there are still some specific initializations to the ownverter board, but that is expected since the temperature measurements are muxed in it. 

To avoid breaking existing code on the field, the previous functions calls are kept for now, they reroute to the new function by default: 

```cpp

void SensorsAPI::enableDefaultTwistSensors()
{
	this->enableDefaultSensors();
}


void SensorsAPI::enableDefaultOwnverterSensors()
{
	this->enableDefaultSensors();
}

```

# Testing the PR

The test repository and branch can be found here: 

https://github.com/luizvilla/Core/tree/default_data_PR_test

Two tests were conducted: 

1- A script (scripts/build_examples.py) pulls all the existing (and future) examples pointed at by the address in `app.ini` and builds them against this modification has been added. All have passed. 

2 - An opposition method code was used with students during the summer. It compiled and worked on the field.  

Expected result from the second test: 
- The test code enables the two legs with a phase shift of 90 degrees.
- By flashing the code on a twist board with the `app.overlay` measurements part commented out you will see the currents in phase, which is normal since they are on two separate ADCs that are synced to their own PWMs

<img width="632" height="474" alt="image" src="https://github.com/user-attachments/assets/6a1028a1-05e3-4387-9c96-b8c30c64e11c" />

- By uncommenting the `app.overlay` cleaning and flashing the code again, you will see the two currents phase shifted, showing that the system works.

<img width="632" height="474" alt="image" src="https://github.com/user-attachments/assets/2598ad63-8abf-45b1-a00f-a35d6315624b" />
